### PR TITLE
Bugfix for probability prediction with caret

### DIFF
--- a/catboost/R-package/R/catboost.caret.R
+++ b/catboost/R-package/R/catboost.caret.R
@@ -104,6 +104,7 @@ catboost.caret$prob <- function(modelFit, newdata, preProc = NULL, submodels = N
   param <- catboost.get_model_params(modelFit)
   if (param$loss_function == "Logloss") {
     prediction <- cbind(1 - prediction, prediction)
+    colnames(prediction) <- modelFit$lev
   }
   return(prediction)
 }


### PR DESCRIPTION
caret:::predict.train expects colnames of a predicted probability dataset match to target levels. 
At the moment, catboost.caret$prob for binary classification returns a matrix with colnames: c("", "prediction")
This is the reason of the error in caret:::predict.train:
```
Error in `[.data.frame`(out, , obsLevels, drop = FALSE) : 
  undefined columns selected
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en