### PR TITLE
Increased number of threads

### DIFF
--- a/catboost/libs/algo/params.h
+++ b/catboost/libs/algo/params.h
@@ -60,7 +60,7 @@ enum class ECounterCalc {
     SkipTest
 };
 
-constexpr int CB_THREAD_LIMIT = 32;
+constexpr int CB_THREAD_LIMIT = 128;
 
 struct TCtrDescription {
     ECtrType CtrType = ECtrType::Borders;


### PR DESCRIPTION
Parameter CB_THREAD_LIMIT increased from 32 to 128 for more complete utilization of multiprocessor systems.

I hereby agree to the terms of the CLA available at: [https://yandex.ru/legal/cla/?lang=en].