### PR TITLE
Make wheel building idempotent.

### DIFF
--- a/catboost/python-package/mk_wheel.py
+++ b/catboost/python-package/mk_wheel.py
@@ -187,7 +187,7 @@ def build(arc_root, out_root, tail_args):
 
     shutil.make_archive(wheel_name, 'zip', 'catboost')
     os.rename(wheel_name + '.zip', wheel_name)
-    shutil.move(wheel_name, os.path.join(py_trait.arc_root, 'catboost', 'python-package'))
+    shutil.move(wheel_name, os.path.join(py_trait.arc_root, 'catboost', 'python-package', wheel_name))
 
     return wheel_name
 


### PR DESCRIPTION
I debug PKGBUILD for [python-catboost-gpu-git](https://aur.archlinux.org/packages/python-catboost-gpu-git/) package. So, if one tries remake python wheel one gets stacktrace as following.

```bash
$ python3 ./mk_wheel.py -DCUDA_ROOT=/opt/cuda
...
$ python3 ./mk_wheel.py -DCUDA_ROOT=/opt/cuda
Ok
/usr/bin/python3 /home/bershatsky/proj/src/aur.archlinux.org/python-catboost/src/catboost/ya make /home/bershatsky/proj/src/aur.archlinux.org/python-catboost/src/catboost/catboost/python-package/catboost --no-src-links -r --output /tmp/tmph3i4p9yd -DPYTHON_CONFIG=python3-config -DNO_DEBUGINFO -DUSE_ARCADIA_PYTHON=no -DCUDA_ROOT=/opt/cuda
Ok
Traceback (most recent call last):
  File "mk_wheel.py", line 198, in <module>
    wheel_name = build(arc_root, out_root, sys.argv[1:])
  File "mk_wheel.py", line 190, in build
    shutil.move(wheel_name, os.path.join(py_trait.arc_root, 'catboost', 'python-package'))
  File "/usr/lib/python3.6/shutil.py", line 542, in move
    raise Error("Destination path '%s' already exists" % real_dst)
shutil.Error: Destination path '/home/bershatsky/proj/src/aur.archlinux.org/python-catboost/src/catboost/catboost/python-package/catboost-0.2.3-cp36-none-manylinux1_x86_64.whl' already exists
```

The reason is sematic of `shutil.move`. Accurate specification of destination fixes this issue.