### PR TITLE
ipywidgets 7x support

### DIFF
--- a/catboost/python-package/catboost/widget/CatboostIpythonInit.js
+++ b/catboost/python-package/catboost/widget/CatboostIpythonInit.js
@@ -1,4 +1,10 @@
-define('catboost_module', ["jupyter-js-widgets"], function(widgets) {
+var moduleBase = 'jupyter-js-widgets';
+
+try{
+    moduleBase = Jupyter.WidgetManager.prototype.loadClass.toString().indexOf('@jupyter-widgets/base') > -1 ? '@jupyter-widgets/base' : 'jupyter-js-widgets';
+} catch(e) {}
+
+define('catboost_module', [moduleBase], function(widgets) {
     var getInstance = function(el) {
             var id = $(el).attr('catboost-id');
 


### PR DESCRIPTION
According to [documentation](http://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Low%20Level.html), widgets must be loaded via
> define('mywidget', ['#at#jupyter-widgets/base'], function(widgets) {

previous way was
> define('mywidget', ['jupyter-js-widgets'], function(widgets) {

I have no idea how to detect the current ipywidgets version via js (and before widget's loading) so here is my workaround

It's seems that is also impossible to switch ipywidgets' version and get a visualization in currently running notebook. Refreshing a page and restarting a kernel are not enough. The old version of code is cached and the only way I found to make visualization work is to create a new notebook.