### PR TITLE
Allow 1*1 input matrix

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -191,7 +191,7 @@ class Pool(_PoolBase):
                     data_shape = tuple(data_shape + tuple([len(data[0])]))
                 else:
                     data_shape = tuple(data_shape + tuple([1]))
-            if not len(data_shape) == 2 or not sum(data_shape) > 2:
+            if not len(data_shape) == 2 or not min(data_shape) > 2:
                 raise CatboostError("Input data has invalid shape or empty: {}. Must be 2 dimensional".format(data_shape))
 
     def _check_label_type(self, label):

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -191,7 +191,7 @@ class Pool(_PoolBase):
                     data_shape = tuple(data_shape + tuple([len(data[0])]))
                 else:
                     data_shape = tuple(data_shape + tuple([1]))
-            if not len(data_shape) == 2 or not min(data_shape) > 2:
+            if not len(data_shape) == 2 or not min(data_shape) > 0:
                 raise CatboostError("Input data has invalid shape or empty: {}. Must be 2 dimensional".format(data_shape))
 
     def _check_label_type(self, label):


### PR DESCRIPTION
This single-line update allows to use 1*1 input matrices when predicting with Python package, as described in the issue #156 .

As a new contributor, I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.