### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following implementations are available:
 
 Tutorials
 --------------
-* Tutorials are avaliable [here](https://github.com/catboost/catboost/tree/master/catboost/tutorials).
+* Tutorials are available [here](https://github.com/catboost/catboost/tree/master/catboost/tutorials).
 
 Catboost models in production
 --------------


### PR DESCRIPTION
avaliable > available

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en