### PR TITLE
Add missing comma and removing border parameter

### DIFF
--- a/catboost/tutorials/catboost_r_tutorial.ipynb
+++ b/catboost/tutorials/catboost_r_tutorial.ipynb
@@ -713,8 +713,7 @@
     "                   depth = 5,\n",
     "                   learning_rate = 0.03,\n",
     "                   l2_leaf_reg = 3.5,\n",
-    "                   border = 0.5,\n",
-    "                   train_dir = 'train_dir'\n",
+    "                   train_dir = 'train_dir',\n",
     "                   logging_level = 'Silent')\n",
     "model <- catboost.train(train_pool, test_pool, fit_params)"
    ]


### PR DESCRIPTION
The border parameter should be added within the loss_function (since the default is 0.5, I believe we shouldn't feature it and just remove it from the list?). 

It runs properly with these changes, fixes #323, 
[https://i.imgur.com/2ktSrW1.png](url)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.



