### PR TITLE
Fix small typo in "Export of CatBoost model as standalone C++ code" tutorial

### DIFF
--- a/catboost/tutorials/advanced_tutorials/catboost_model_export_as_cpp_code_tutorial.md
+++ b/catboost/tutorials/advanced_tutorials/catboost_model_export_as_cpp_code_tutorial.md
@@ -1,4 +1,4 @@
-Export of CatBbost model as standalone C++ code
+Export of CatBoost model as standalone C++ code
 ===============================================
 
 Catboost model could be saved as standalone C++ code. This can ease an integration of a generated model into an application built from C++ sources, simplify porting the model to an architecture not direcly supported by CatBoost (eq. ARM), or allow manual exploration and editing of the model parameters by advanced users.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en