### PR TITLE
Added an option to allow negative weights

### DIFF
--- a/catboost/app/bind_options.cpp
+++ b/catboost/app/bind_options.cpp
@@ -570,6 +570,12 @@ void ParseCommandLine(int argc, const char* argv[],
             (*plainJsonPtr)["allow_const_label"] = true;
         });
 
+    parser.AddLongOption("allow-negative-weights", "Allow negative document weights. EXPERIMENTAL, use at own peril")
+        .NoArgument()
+        .Handler0([plainJsonPtr]() {
+            (*plainJsonPtr)["allow_negative_weights"] = true;
+        });
+
     parser.AddLongOption("classes-count", "number of classes")
         .RequiredArgument("int")
         .Handler1T<int>([plainJsonPtr](const int classesCount) {

--- a/catboost/libs/options/data_processing_options.h
+++ b/catboost/libs/options/data_processing_options.h
@@ -13,6 +13,7 @@ namespace NCatboostOptions {
             : IgnoredFeatures("ignored_features", TVector<int>())
             , HasTimeFlag("has_time", false)
             , AllowConstLabel("allow_const_label", false)
+	    , AllowNegativeWeights("allow_negative_weights", false)
             , FloatFeaturesBinarization("float_features_binarization", TBinarizationOptions(EBorderSelectionType::GreedyLogSum, 128, ENanMode::Min))
             , ClassesCount("classes_count", 0)
             , ClassWeights("class_weights", TVector<float>())
@@ -23,18 +24,18 @@ namespace NCatboostOptions {
         }
 
         void Load(const NJson::TJsonValue& options) {
-            CheckedLoad(options, &IgnoredFeatures, &HasTimeFlag, &AllowConstLabel, &FloatFeaturesBinarization, &ClassesCount, &ClassWeights, &ClassNames, &GpuCatFeaturesStorage);
+            CheckedLoad(options, &IgnoredFeatures, &HasTimeFlag, &AllowConstLabel, &AllowNegativeWeights, &FloatFeaturesBinarization, &ClassesCount, &ClassWeights, &ClassNames, &GpuCatFeaturesStorage);
             CB_ENSURE(FloatFeaturesBinarization->BorderCount <= GetMaxBinCount(), "Error: catboost doesn't support binarization with >= 256 levels");
         }
 
         void Save(NJson::TJsonValue* options) const {
-            SaveFields(options, IgnoredFeatures, HasTimeFlag, AllowConstLabel, FloatFeaturesBinarization, ClassesCount, ClassWeights, ClassNames, GpuCatFeaturesStorage);
+            SaveFields(options, IgnoredFeatures, HasTimeFlag, AllowConstLabel, AllowNegativeWeights, FloatFeaturesBinarization, ClassesCount, ClassWeights, ClassNames, GpuCatFeaturesStorage);
         }
 
         bool operator==(const TDataProcessingOptions& rhs) const {
-            return std::tie(IgnoredFeatures, HasTimeFlag, AllowConstLabel, FloatFeaturesBinarization, ClassesCount, ClassWeights,
+            return std::tie(IgnoredFeatures, HasTimeFlag, AllowConstLabel, AllowNegativeWeights, FloatFeaturesBinarization, ClassesCount, ClassWeights,
                             ClassNames, GpuCatFeaturesStorage) ==
-                   std::tie(rhs.IgnoredFeatures, rhs.HasTimeFlag, rhs.AllowConstLabel, rhs.FloatFeaturesBinarization, rhs.ClassesCount,
+	    std::tie(rhs.IgnoredFeatures, rhs.HasTimeFlag, rhs.AllowConstLabel, rhs.AllowNegativeWeights, rhs.FloatFeaturesBinarization, rhs.ClassesCount,
                             rhs.ClassWeights, rhs.ClassNames, rhs.GpuCatFeaturesStorage);
         }
 
@@ -45,6 +46,7 @@ namespace NCatboostOptions {
         TOption<TVector<int>> IgnoredFeatures;
         TOption<bool> HasTimeFlag;
         TOption<bool> AllowConstLabel;
+	TOption<bool> AllowNegativeWeights;
         TOption<TBinarizationOptions> FloatFeaturesBinarization;
         TOption<ui32> ClassesCount;
         TOption<TVector<float>> ClassWeights;

--- a/catboost/libs/options/plain_options_helper.cpp
+++ b/catboost/libs/options/plain_options_helper.cpp
@@ -191,6 +191,7 @@ namespace NCatboostOptions {
         CopyOption(plainOptions, "ignored_features", &dataProcessingOptions, &seenKeys);
         CopyOption(plainOptions, "has_time", &dataProcessingOptions, &seenKeys);
         CopyOption(plainOptions, "allow_const_label", &dataProcessingOptions, &seenKeys);
+        CopyOption(plainOptions, "allow_negative_weights", &dataProcessingOptions, &seenKeys);
         CopyOption(plainOptions, "classes_count", &dataProcessingOptions, &seenKeys);
         CopyOption(plainOptions, "class_names", &dataProcessingOptions, &seenKeys);
         CopyOption(plainOptions, "class_weights", &dataProcessingOptions, &seenKeys);

--- a/catboost/libs/train_lib/cross_validation.cpp
+++ b/catboost/libs/train_lib/cross_validation.cpp
@@ -88,6 +88,7 @@ static void PopulateData(const TPool& pool,
 static void PrepareFolds(
     const NCatboostOptions::TLossDescription& lossDescription,
     bool allowConstLabel,
+    bool allowNegativeWeights,
     const TPool& pool,
     const TVector<THolder<TLearnContext>>& contexts,
     const TCrossValidationParams& cvParams,
@@ -172,7 +173,7 @@ static void PrepareFolds(
             &testData.AllFeatures
         );
 
-        CheckLearnConsistency(lossDescription, allowConstLabel, learnData);
+        CheckLearnConsistency(lossDescription, allowConstLabel, allowNegativeWeights, learnData);
         CheckTestConsistency(lossDescription, learnData, testData);
 
         folds->push_back(learnData);
@@ -316,7 +317,10 @@ void CrossValidate(
 
     TVector<TDataset> learnFolds;
     TVector<TDataset> testFolds;
-    PrepareFolds(ctx->Params.LossFunctionDescription.Get(), ctx->Params.DataProcessingOptions->AllowConstLabel, pool, contexts, cvParams, &learnFolds, &testFolds);
+    PrepareFolds(ctx->Params.LossFunctionDescription.Get(),
+		 ctx->Params.DataProcessingOptions->AllowConstLabel, 
+		 ctx->Params.DataProcessingOptions->AllowNegativeWeights,
+		 pool, contexts, cvParams, &learnFolds, &testFolds);
 
     for (size_t foldIdx = 0; foldIdx < learnFolds.size(); ++foldIdx) {
         contexts[foldIdx]->InitContext(learnFolds[foldIdx], {&testFolds[foldIdx]});

--- a/catboost/libs/train_lib/preprocess.h
+++ b/catboost/libs/train_lib/preprocess.h
@@ -18,6 +18,7 @@ void Preprocess(const NCatboostOptions::TLossDescription& lossDescription,
 void CheckLearnConsistency(
     const NCatboostOptions::TLossDescription& lossDescription,
     bool allowConstLabel,
+    bool allowNegativeWeights,
     const TDataset& learnData
 );
 /// Check 2 of 2: consistency of the testData sets with the learnData.

--- a/catboost/libs/train_lib/train_model.cpp
+++ b/catboost/libs/train_lib/train_model.cpp
@@ -441,7 +441,10 @@ class TCPUModelTrainer : public IModelTrainer {
         const TVector<float>& classWeights = ctx.Params.DataProcessingOptions->ClassWeights;
         const auto& labelConverter = ctx.LearnProgress.LabelConverter;
         Preprocess(ctx.Params.LossFunctionDescription, classWeights, labelConverter, learnData);
-        CheckLearnConsistency(ctx.Params.LossFunctionDescription, ctx.Params.DataProcessingOptions->AllowConstLabel.Get(), learnData);
+        CheckLearnConsistency(ctx.Params.LossFunctionDescription, 
+			      ctx.Params.DataProcessingOptions->AllowConstLabel.Get(),
+			      ctx.Params.DataProcessingOptions->AllowNegativeWeights.Get(),
+			      learnData);
         for (TDataset& testData : testDatasets) {
             Preprocess(ctx.Params.LossFunctionDescription, classWeights, labelConverter, testData);
             CheckTestConsistency(ctx.Params.LossFunctionDescription, learnData, testData);

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1743,6 +1743,8 @@ class CatBoostClassifier(CatBoost):
         the Categ features to Num and the choice of a tree structure).
     allow_const_label : bool, [default=False]
         To allow the constant label value in dataset.
+    allow_negative_weights : bool [default=False]
+        To allow negative document weights in dataset.
     classes_count : int, [default=None]
         The upper limit for the numeric class label.
         Defines the number of classes for multiclassification.
@@ -1878,6 +1880,7 @@ class CatBoostClassifier(CatBoost):
         max_ctr_complexity=None,
         has_time=None,
         allow_const_label=None,
+        allow_negative_weights=None,
         classes_count=None,
         class_weights=None,
         one_hot_max_size=None,
@@ -2221,6 +2224,7 @@ class CatBoostRegressor(CatBoost):
         max_ctr_complexity=None,
         has_time=None,
         allow_const_label=None,
+        allow_negative_weights=None,
         one_hot_max_size=None,
         random_strength=None,
         name=None,


### PR DESCRIPTION
Adds an option to allow negative document weights.

Negative weights are not insanity, they are commonly used in High-Energy Physics in the following way. Take a classification dataset. Add some noise documents, that are from neither class. Then, by some way independent of the features present in the dataset, for each document compute the probability of it being noise. Then, there is a way to compute weights from these probabilities in such a way, that, when the dataset is weighted with those weights, the feature's distribution will be that of the original dataset before the noise addition. More in the paper: https://arxiv.org/abs/physics/0402083

Example pool: https://cernbox.cern.ch/index.php/s/XK3ZuNlGCg1Dtc3