### PR TITLE
exclude ipynb files from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 contrib/* linguist-vendored
+*.ipynb linguist-vendored
 *.h linguist-language=C++


### PR DESCRIPTION
Currently the main language for this repo is Jupyter Notebook, which is a bit confusing, obviously it should be C++