### PR TITLE
Fix string missing format

### DIFF
--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -1263,7 +1263,9 @@ class FeaturesData(object):
                 for i, name in enumerate(feature_names):
                     if type(name) != str:
                         raise CatboostError(
-                            'type of {}_feature_names[{}]: expected str, found {}'
+                            'type of {}_feature_names[{}]: expected str, found {}'.format(
+                                part_name, i, type(name)
+                            )
                         )
                 if feature_data.shape[1] != len(feature_names):
                     raise CatboostError(


### PR DESCRIPTION
Now the error it prints is 
```CatboostError: type of {}_feature_names[{}]: expected str, found {}```
since the string is not properly formatted. Without looking into code, people will be confused.

_I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en_
