### PR TITLE
Replace -X/-Y in CLI with --cv catboost_clickhouse_sprint_02.02.2019 …

### DIFF
--- a/catboost/app/bind_options.cpp
+++ b/catboost/app/bind_options.cpp
@@ -82,10 +82,9 @@ inline static void BindPoolLoadParams(NLastGetopt::TOpts* parser, NCatboostOptio
             loadParamsPtr->TestGroupWeightsFilePath = TPathWithScheme(str, "file");
         });
 
-    const auto allCvTypes = GetAllCvTypes();
     const auto cvDescription = TString::Join(
         "Cross validation type. Should be one of: ",
-        JoinSeq(", ", allCvTypes),
+        GetEnumAllNames<ECrossValidation>());
         ". Classical: test on fold n of k, n is 0-based",
         ". Inverted: train on fold n of k, n is 0-based",
         ". All cv types have two parameters n and k, they should be written in format cvtype:n;k.");

--- a/catboost/app/bind_options.cpp
+++ b/catboost/app/bind_options.cpp
@@ -82,29 +82,26 @@ inline static void BindPoolLoadParams(NLastGetopt::TOpts* parser, NCatboostOptio
             loadParamsPtr->TestGroupWeightsFilePath = TPathWithScheme(str, "file");
         });
 
-    parser->AddCharOption('X', "cross validation, test on fold n of k, n is 0-based")
-        .RequiredArgument("n/k")
-        .Handler1T<TStringBuf>([loadParamsPtr](const TStringBuf& str) {
+    const auto allCvTypes = GetAllCvTypes();
+    const auto cvDescription = TString::Join(
+        "Cross validation type. Should be one of: ",
+        JoinSeq(", ", allCvTypes),
+        ". Classical: test on fold n of k, n is 0-based",
+        ". Inverted: train on fold n of k, n is 0-based",
+        ". All cv types have two parameters n and k, they should be written in format cvtype:n;k.");
+    parser->AddLongOption("cv", cvDescription)
+        .RequiredArgument("string")
+        .Handler1T<TString>([loadParamsPtr](const auto& str) {
             CB_ENSURE(
                 !loadParamsPtr->CvParams.Initialized(),
                 "Cross-validation params have already been initialized"
             );
-            Split(str,
-                  '/', loadParamsPtr->CvParams.FoldIdx, loadParamsPtr->CvParams.FoldCount);
-            loadParamsPtr->CvParams.Inverted = false;
-            loadParamsPtr->CvParams.Check();
-        });
-
-    parser->AddCharOption('Y', "inverted cross validation, train on fold n of k, n is 0-based")
-        .RequiredArgument("n/k")
-        .Handler1T<TStringBuf>([loadParamsPtr](const TStringBuf& str) {
-            CB_ENSURE(
-                !loadParamsPtr->CvParams.Initialized(),
-                "Cross-validation params have already been initialized"
-            );
-            Split(str,
-                  '/', loadParamsPtr->CvParams.FoldIdx, loadParamsPtr->CvParams.FoldCount);
-            loadParamsPtr->CvParams.Inverted = true;
+            const auto cvType = FromString<ECrossValidation>(TStringBuf(str).Before(':'));
+            const auto params = TStringBuf(str).After(':');
+            if (cvType == ECrossValidation::Classical || cvType == ECrossValidation::Inverted) {
+                Split(params, ';', loadParamsPtr->CvParams.FoldIdx, loadParamsPtr->CvParams.FoldCount);
+                loadParamsPtr->CvParams.Inverted = (cvType == ECrossValidation::Inverted);
+            }
             loadParamsPtr->CvParams.Check();
         });
 

--- a/catboost/app/bind_options.cpp
+++ b/catboost/app/bind_options.cpp
@@ -84,7 +84,7 @@ inline static void BindPoolLoadParams(NLastGetopt::TOpts* parser, NCatboostOptio
 
     const auto cvDescription = TString::Join(
         "Cross validation type. Should be one of: ",
-        GetEnumAllNames<ECrossValidation>());
+        GetEnumAllNames<ECrossValidation>(),
         ". Classical: test on fold n of k, n is 0-based",
         ". Inverted: train on fold n of k, n is 0-based",
         ". All cv types have two parameters n and k, they should be written in format cvtype:n;k.");

--- a/catboost/libs/options/enum_helpers.cpp
+++ b/catboost/libs/options/enum_helpers.cpp
@@ -19,6 +19,11 @@ TConstArrayRef<ELossFunction> GetAllObjectives() {
     return allObjectives;
 }
 
+TConstArrayRef<ECrossValidation> GetAllCvTypes() {
+    static TVector<ECrossValidation> allCvTypes = {
+        ECrossValidation::Classical, ECrossValidation::Inverted};
+    return allCvTypes;
+}
 
 bool IsSingleDimensionalError(ELossFunction lossFunction) {
     return (lossFunction != ELossFunction::MultiClass &&

--- a/catboost/libs/options/enum_helpers.cpp
+++ b/catboost/libs/options/enum_helpers.cpp
@@ -19,12 +19,6 @@ TConstArrayRef<ELossFunction> GetAllObjectives() {
     return allObjectives;
 }
 
-TConstArrayRef<ECrossValidation> GetAllCvTypes() {
-    static TVector<ECrossValidation> allCvTypes = {
-        ECrossValidation::Classical, ECrossValidation::Inverted};
-    return allCvTypes;
-}
-
 bool IsSingleDimensionalError(ELossFunction lossFunction) {
     return (lossFunction != ELossFunction::MultiClass &&
             lossFunction != ELossFunction::MultiClassOneVsAll);

--- a/catboost/libs/options/enum_helpers.h
+++ b/catboost/libs/options/enum_helpers.h
@@ -7,8 +7,6 @@
 
 TConstArrayRef<ELossFunction> GetAllObjectives();
 
-TConstArrayRef<ECrossValidation> GetAllCvTypes();
-
 bool IsSingleDimensionalError(ELossFunction lossFunction);
 
 bool IsMultiDimensionalError(ELossFunction lossFunction);

--- a/catboost/libs/options/enum_helpers.h
+++ b/catboost/libs/options/enum_helpers.h
@@ -7,6 +7,8 @@
 
 TConstArrayRef<ELossFunction> GetAllObjectives();
 
+TConstArrayRef<ECrossValidation> GetAllCvTypes();
+
 bool IsSingleDimensionalError(ELossFunction lossFunction);
 
 bool IsMultiDimensionalError(ELossFunction lossFunction);

--- a/catboost/libs/options/enums.h
+++ b/catboost/libs/options/enums.h
@@ -91,6 +91,11 @@ enum class ENanMode {
     Forbidden
 };
 
+enum class ECrossValidation {
+    Classical,
+    Inverted
+};
+
 enum class ELossFunction {
     /* binary classification errors */
 

--- a/catboost/pytest/cuda_tests/test_gpu.py
+++ b/catboost/pytest/cuda_tests/test_gpu.py
@@ -17,6 +17,7 @@ from catboost_pytest_lib import (
     execute_catboost_fit,
     get_limited_precision_dsv_diff_tool,
     local_canonical_file,
+    format_crossvalidation
 )
 
 CATBOOST_PATH = yatest.common.binary_path("catboost/app/catboost")
@@ -781,7 +782,7 @@ def test_cv(is_inverted, boosting_type):
         '-w', '0.03',
         '-T', '4',
         '-m', output_model_path,
-        ('-Y' if is_inverted else '-X'), '2/10',
+        '--cv', format_crossvalidation(is_inverted, 2, 10),
         '--eval-file', output_eval_path,
     )
     fit_catboost_gpu(params)
@@ -803,7 +804,7 @@ def test_cv_for_query(is_inverted, boosting_type):
         '-i', '10',
         '-T', '4',
         '-m', output_model_path,
-        ('-Y' if is_inverted else '-X'), '2/7',
+        '--cv', format_crossvalidation(is_inverted, 2, 7),
         '--eval-file', output_eval_path,
     )
     fit_catboost_gpu(params)
@@ -826,7 +827,7 @@ def test_cv_for_pairs(is_inverted, boosting_type):
         '-i', '10',
         '-T', '4',
         '-m', output_model_path,
-        ('-Y' if is_inverted else '-X'), '2/7',
+        '--cv', format_crossvalidation(is_inverted, 2, 7),
         '--eval-file', output_eval_path,
     )
     fit_catboost_gpu(params)

--- a/catboost/pytest/lib/__init__.py
+++ b/catboost/pytest/lib/__init__.py
@@ -168,3 +168,8 @@ def get_limited_precision_dsv_diff_tool(diff_limit, have_header=False):
 
 def local_canonical_file(*args, **kwargs):
     return yatest.common.canonical_file(*args, local=True, **kwargs)
+
+
+def format_crossvalidation(is_inverted, n, k):
+    cv_type = 'Inverted' if is_inverted else 'Classical'
+    return '{}:{};{}'.format(cv_type, n, k)

--- a/catboost/pytest/test.py
+++ b/catboost/pytest/test.py
@@ -17,7 +17,8 @@ from catboost_pytest_lib import (
     apply_catboost,
     permute_dataset_columns,
     generate_random_labeled_set,
-    execute_catboost_fit
+    execute_catboost_fit,
+    format_crossvalidation
 )
 
 CATBOOST_PATH = yatest.common.binary_path("catboost/app/catboost")
@@ -40,11 +41,6 @@ OVERFITTING_DETECTOR_TYPE = ['IncToDec', 'Iter']
 # default block size (5000000) is too big to run in parallel on these tests
 SCORE_CALC_OBJ_BLOCK_SIZES = ['60', '5000000']
 SCORE_CALC_OBJ_BLOCK_SIZES_IDS = ['calc_block=60', 'calc_block=5000000']
-
-
-def format_crossvalidation(is_inverted, n, k):
-    cv_type = 'Inverted' if is_inverted else 'Classical'
-    return '{}:{};{}'.format(cv_type, n, k)
 
 
 @pytest.mark.parametrize('boosting_type', BOOSTING_TYPE)

--- a/catboost/pytest/test.py
+++ b/catboost/pytest/test.py
@@ -1484,7 +1484,7 @@ def test_cv_for_query(is_inverted, boosting_type):
         '-i', '10',
         '-T', '4',
         '-m', output_model_path,
-        format_crossvalidation(is_inverted, 2, 7),
+        '--cv', format_crossvalidation(is_inverted, 2, 7),
         '--eval-file', output_eval_path,
     )
     yatest.common.execute(cmd)


### PR DESCRIPTION
Remove -X/-Y from CLI. Replace with --cv Classical:n;k and --cv Inverted:n;k.

Note that docs at https://tech.yandex.com/catboost/doc/dg/concepts/cli-reference_cross-validation-docpage/ should be updated as follows.

```
Execution format

catboost fit -f <file path> [--cv <value>] [--cv-rand <value>] [other parameters]

Options
...
--cv 
Perform cross validation to score the model. Supports two modes. Classical: perform cross validation to score the model by excluding a small fold from the training dataset and using it for testing. Inverted: perform cross validation to score the model by excluding a small fold from the validation dataset and using it for training.

Format for specifying values:

<cvtype>:<n>;<k>
cvtype is either Classical or Inverted.
 n is the identifier of the fold to exclude.
 k is the number of folds to split the input data into.
The inequality n < k must be true.

For example, to exclude the fold indexed 13 from the training dataset and use it for testing, set the value Classical:13;15. To exclude the fold indexed 13 from the validation dataset and use it for training, set the value Inverted:13;15.

The data is randomly shuffled before splitting.

--cv-rand
...
It must be used with --cv <value> parameter.

```

--
I hereby agree to the terms of the CLA available at  https://yandex.ru/legal/cla/?lang=en.
