### PR TITLE
Add sample weights usage at greedy binarization.

### DIFF
--- a/library/grid_creator/binarization.h
+++ b/library/grid_creator/binarization.h
@@ -15,7 +15,15 @@ THashSet<float> BestSplit(
     TVector<float>& features,
     int maxBordersCount,
     EBorderSelectionType type,
-    bool nanValueIsInfty = false,
+    bool nanValueIsInfty = false, // Sounds like there may be a border between usual values and nans. Better call it filterNans.
+    bool featuresAreSorted = false);
+
+// TODO: support EBorderSelectionType
+THashSet<float> BestWeightedSplit(
+    const TVector<float>& featureValues,
+    const TVector<float>& weights,
+    int maxBordersCount,
+    bool filterNans = false,
     bool featuresAreSorted = false);
 
 size_t CalcMemoryForFindBestSplit(

--- a/library/grid_creator/ut/binarization_ut.cpp
+++ b/library/grid_creator/ut/binarization_ut.cpp
@@ -6,31 +6,174 @@
 #include <util/generic/hash_set.h>
 #include <util/generic/serialized_enum.h>
 #include <util/generic/vector.h>
+#include <util/generic/algorithm.h>
+#include <util/generic/ymath.h>
+
+
+#include <random>
+#include <algorithm>
 
 static const TConstArrayRef<size_t> MAX_BORDER_COUNT_VALUES = {1, 10, 128};
 static const TConstArrayRef<bool> NAN_IS_INFINITY_VALUES = {true, false};
+static const TVector<EBorderSelectionType> BORDER_SELECTION_TYPES = (
+    GetEnumAllValues<EBorderSelectionType>().Materialize());
 
-template <typename C, typename F>
-static void ForEachValue(const C& values, F&& foo) {
-    for (const auto& v : values) {
-        foo(v);
+void TestAll(const TVector<float>& values, const THashSet<float>& expected_borders,
+                const TVector<EBorderSelectionType>& borderSelectionTypes = BORDER_SELECTION_TYPES,
+                const TConstArrayRef<size_t>& borderCounts = MAX_BORDER_COUNT_VALUES,
+                const TConstArrayRef<bool>& nanIsInfinityValues = NAN_IS_INFINITY_VALUES) {
+    for (const auto& borderSelectionAlgorithm : borderSelectionTypes) {
+        for (const auto& nanIsInfinity : nanIsInfinityValues) {
+            for (const auto& maxBorderCount : borderCounts) {
+                TVector<float> values_copy(values);
+                auto borders = BestSplit(values_copy, maxBorderCount, borderSelectionAlgorithm, nanIsInfinity);
+                UNIT_ASSERT_EQUAL_C(borders, expected_borders,
+                    GetEnumNames<EBorderSelectionType>().at(borderSelectionAlgorithm));
+            }
+        }
     }
 }
 
-template <typename E, typename F>
-static void ForEachEnumValue(F&& foo) {
-    ForEachValue(GetEnumAllValues<E>(), foo);
+TVector<float> Arange(int start, int end) {
+    TVector<float> values;
+    auto curr = start;
+    while (curr < end) {
+        values.push_back(curr++);
+    }
+    return values;
+}
+
+TVector<float> Arange(int end) {
+    return Arange(0, end);
+}
+
+THashSet<float> GetAllBorders(TVector<float> values) {
+    Sort(values.begin(), values.end());
+    THashSet<float> result;
+    for (auto valueIterator = values.begin(); valueIterator + 1 != values.end(); ++valueIterator) {
+        if (*valueIterator != *(valueIterator + 1)) {
+            result.insert(0.5f * (*valueIterator + *(valueIterator + 1)));
+        }
+    }
+    return result;
 }
 
 Y_UNIT_TEST_SUITE(BinarizationTests) {
     Y_UNIT_TEST(TestEmpty) {
-        ForEachEnumValue<EBorderSelectionType>([](const auto borderSelectionAlgorithm) {
-            ForEachValue(NAN_IS_INFINITY_VALUES, [&](const auto nanIsInfinity) {
-                ForEachValue(MAX_BORDER_COUNT_VALUES, [&](const auto maxBorderCount) {
-                    TVector<float> values;
-                    BestSplit(values, maxBorderCount, borderSelectionAlgorithm, nanIsInfinity);
-                });
-            });
-        });
+        TVector<float> values;
+        TestAll(values, {});
+    }
+
+    Y_UNIT_TEST(TestSingleValue) {
+        TVector<EBorderSelectionType> borderSelectionAlgorithms = {
+            EBorderSelectionType::GreedyLogSum, EBorderSelectionType::Median,
+            EBorderSelectionType::Uniform, EBorderSelectionType::UniformAndQuantiles
+        }; // test causes error for EBorderSelectionType::MinEntropy, EBorderSelectionType::MaxLogSum
+        TestAll({0.0}, {}, borderSelectionAlgorithms);
+        TVector<float> values(5, 0.0);
+        TestAll(values, {}, borderSelectionAlgorithms);
+    }
+
+    Y_UNIT_TEST(TestFullSplits) {
+        TVector<float> values = {1, 3, 5, 7, 9, 100};
+        TestAll(values, GetAllBorders(values), {
+            EBorderSelectionType::MaxLogSum, EBorderSelectionType::MinEntropy,
+            EBorderSelectionType::GreedyLogSum, EBorderSelectionType::Median},
+            {5, 6, 10, 128});
+    }
+}
+
+Y_UNIT_TEST_SUITE(WeightedBinarizationTests) {
+    Y_UNIT_TEST(TestEmpty) {
+        THashSet<float> expected_borders;
+        UNIT_ASSERT_EQUAL(expected_borders, BestWeightedSplit({}, {}, 1, false, true));
+        UNIT_ASSERT_EQUAL(expected_borders,
+            BestWeightedSplit({1, 2, 3, 4}, {+0.0f, +0.0f, -0.0f, 1.0f}, 1, true, false));
+        UNIT_ASSERT_EQUAL(expected_borders,
+                          BestWeightedSplit({1, 2, 3, 4}, {-1.0f, -1.0f, -1.0f, 1.0f}, 1, true, false));
+    }
+
+    Y_UNIT_TEST(TestSmall) {
+        TVector<float> featureValues = {1.0f, 2.0f};
+        {
+            TVector<float> weights = {1.0f, 1.0f};
+            auto borders = BestWeightedSplit(featureValues, weights, 1, true, true);
+            UNIT_ASSERT_EQUAL(borders, GetAllBorders(featureValues));
+        }
+        {
+            TVector<float> weights = {10.0f, 0.1f};
+            auto borders = BestWeightedSplit(featureValues, weights, 1, true, true);
+            UNIT_ASSERT_EQUAL(borders, GetAllBorders(featureValues));
+        }
+        {
+            TVector<float> weights = {10.0f, std::numeric_limits<float>::min()};
+            auto borders = BestWeightedSplit(featureValues, weights, 1, true, true);
+            UNIT_ASSERT_EQUAL(borders, GetAllBorders(featureValues));
+        }
+    }
+
+    Y_UNIT_TEST(TestFullSplits) {
+        TVector<float> values = {1, 3, 5, 7, 9, 100};
+        TVector<int> borderCounts = {5, 6, 10, 128};
+        for (auto borderCount : borderCounts) {
+            {
+                TVector weights(6, 1.0f);
+                auto borders = BestWeightedSplit(values, weights, borderCount, true, true);
+                UNIT_ASSERT_EQUAL(borders, GetAllBorders(values));
+            }
+            {
+                auto borders = BestWeightedSplit(
+                    values, {1.0, 2.0, 4.0, 32.0, 16.0, 8.0}, borderCount, true, true);
+                UNIT_ASSERT_EQUAL(borders, GetAllBorders(values));
+            }
+            {
+                TVector weights(6, std::numeric_limits<float>::min());
+                auto borders = BestWeightedSplit(values, weights, borderCount, true, true);
+                UNIT_ASSERT_EQUAL(borders, GetAllBorders(values));
+            }
+        }
+    }
+
+    Y_UNIT_TEST(TestConsistency) {
+        const size_t test_size = 100;
+        for (int seed : Arange(10)) {
+            std::mt19937 generator(seed);
+            std::uniform_int_distribution<int> rand_int(0, test_size);
+            TVector<float> values;
+            for (size_t i = 0; i < test_size; ++i) {
+                values.push_back(rand_int(generator));
+            }
+            const TVector<float> weights(100, 1);
+            for (int bordersCount : {3, 10, 50, 256}) {
+                auto values_copy = values;
+                const auto usual_borders = BestSplit(values_copy, bordersCount,
+                                                     EBorderSelectionType::GreedyLogSum);
+                const auto weighthed_borders = BestWeightedSplit(values, weights, bordersCount);
+                UNIT_ASSERT_EQUAL(usual_borders, weighthed_borders);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(TestRuntime) {
+        const TVector<float> featureValues = Arange(-50, 50);
+        const size_t test_size = featureValues.size();
+        TVector<float> weights;
+        const float weightLogStep = log(test_size) / test_size;
+        for (int val = 0; val < static_cast<int>(test_size); ++val) {
+            weights.push_back(sqrt(test_size) * exp(- val * weightLogStep));
+        }
+
+        for (int seed : Arange(10)) {
+            std::mt19937 generator(seed);
+            std::shuffle(weights.begin(), weights.end(), generator);
+            for (size_t bordersCount : {3, 10, 50, 256}) {
+                UNIT_ASSERT_EQUAL(
+                    BestWeightedSplit(featureValues, weights, bordersCount, true, false).size(),
+                    Min(bordersCount, test_size - 1));
+                UNIT_ASSERT_EQUAL(
+                    BestWeightedSplit(featureValues, weights, bordersCount, true, true).size(),
+                    Min(bordersCount, test_size - 1));
+            }
+        }
     }
 }


### PR DESCRIPTION
Привет!
У меня еще нет ощущения что дело завершено, но уже хотелось бы посоветоваться. Особенно про то, какой в итоге сделать интерфейс в h-нике.

Также у меня есть предложение:
    Вычисление медианной сетки и жадную бинаризацию можно ускорить за счет того, что вектор значений фичи не нужно сортировать полностью. Грубо говоря идея в том, что можно рекурсивно делать qsort, и прерываться если порядок значений в диапазоне, котрый просят отсортировать не влияет на ответ (потому что нужные квантили и соседние с ними значения уже вне этого диапазона). Можно получить в обоих случаях ассимптотику n log(k) (n - размер выборки, k - число корзинок). Хотя понятно, что log(n) и log(k) отличаются в "практическую константу" раз.

Еще хочу поделиться найденным багом: пусть у нас корзинка веса (a + b) и мы ее разбиваем на две с весами a и b. Казалось бы после этого скор (MaxSumLog) разбиения должен возрасти но это не всегда так! (неравенство f(a) + f(b) > f(a + b) работает для вогнутых функций если f(0) = 0). Я и автор предыдущей версии бинаризатора попались в эту засаду и написав тест я с удивлением обнаружил, что жадный бинаризатор не хочет сплитить корзинку из двух значений, потому что такой сплит не дает прироста к скору (а если  например включены веса и в сумме они <=1 то вообще ничего не будет сплититься). Может заменить в MaxSumLog: log(x) -> log(1 + x)? (на всякий случай, а log(1 + x) вроде тоже ничем не плох).

