### PR TITLE
added setup.py to enable 'pip install -e .'

### DIFF
--- a/catboost/python-package/setup.py
+++ b/catboost/python-package/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup, find_packages
+
+PACKAGE = 'catboost'
+
+setup(
+    name=PACKAGE,
+    version="0.13",
+
+    author="CatBoost Developers",
+    description="Python package for catboost",
+    license="Apache License, Version 2.0",
+
+    packages=find_packages(),
+    install_requires=[
+        'enum34',
+        'six',
+        'numpy >= 1.11.1',
+        'pandas >= 0.19.1'
+    ],
+)


### PR DESCRIPTION
This PR adds a setup.py file to the python package. This allows installation of the package via pip using pip install -e .` (assuming current working directory is `/catboost/python-package`) which installs the package into the current virtual environment by creating a egg file which links back to the current source folder rather than copying the files into the site or user packages folder. It's easier to manage than adding /catboost/python-package to the PATH as it allows multiple different versions to be installed in different virtualenvs without conflict.