### PR TITLE
[WIP] Expectile Regression

### DIFF
--- a/catboost/cuda/targets/gpu_metrics.cpp
+++ b/catboost/cuda/targets/gpu_metrics.cpp
@@ -209,7 +209,8 @@ namespace NCatboostCuda {
                 case ELossFunction::Lq:
                 case ELossFunction::NumErrors:
                 case ELossFunction::MAPE:
-                case ELossFunction::Poisson: {
+                case ELossFunction::Poisson:
+                case ELossFunction::Expectile: {
                     float alpha = 0.5;
                     auto tmp = TVec::Create(cursor.GetMapping().RepeatOnAllDevices(1));
                     //TODO(noxoomo): make param dispatch on device side
@@ -495,7 +496,8 @@ namespace NCatboostCuda {
             case ELossFunction::Accuracy:
             case ELossFunction::ZeroOneLoss:
             case ELossFunction::NumErrors:
-            case ELossFunction::Poisson: {
+            case ELossFunction::Poisson:
+            case ELossFunction::Expectile: {
                 result.push_back(new TGpuPointwiseMetric(metricDescription, approxDim));
                 break;
             }

--- a/catboost/cuda/targets/kernel/pointwise_targets.cu
+++ b/catboost/cuda/targets/kernel/pointwise_targets.cu
@@ -31,6 +31,32 @@ namespace NKernel {
         }
     };
 
+    struct TExpectileTarget  {
+        float Alpha;
+
+        __host__ __device__ __forceinline__ TExpectileTarget(float alpha = 0.5)
+                : Alpha(alpha) {
+        }
+
+        __device__ __forceinline__ float Score(float target, float prediction) const {
+            const float val = target - prediction;
+            const float multiplier = (val > 0) ? Alpha : (1 - Alpha);
+            return multiplier * val * val;
+        }
+
+        __device__ __forceinline__ float Der(float target, float prediction) const {
+            const float val = target - prediction;
+            const float multiplier = (val > 0) ? Alpha : (1 - Alpha);
+            return 2.0 * multiplier * val;
+        }
+
+        __device__ __forceinline__ float Der2(float target, float prediction) const {
+            const float val = target - prediction;
+            const float multiplier = (val > 0) ? Alpha : (1 - Alpha);
+            return 2.0 * multiplier;
+        }
+    };
+
     struct TLogLinQuantileTarget {
         float Alpha;
 
@@ -367,6 +393,12 @@ namespace NKernel {
         const ui32 blockSize = 1024;
         switch (loss)
         {
+            case ELossFunction::Expectile:
+            {
+                TExpectileTarget target(alpha);
+                POINTWISE_TARGET()
+                break;
+            }
             case ELossFunction::Quantile:
             case ELossFunction::MAE:
             {

--- a/catboost/cuda/targets/pointwise_target_impl.h
+++ b/catboost/cuda/targets/pointwise_target_impl.h
@@ -287,6 +287,10 @@ namespace NCatboostCuda {
                     Alpha = NCatboostOptions::GetAlpha(targetOptions);
                     break;
                 }
+                case ELossFunction::Expectile: {
+                    Alpha = NCatboostOptions::GetAlpha(targetOptions);
+                    break;
+                }
                 case ELossFunction::Logloss: {
                     Border = NCatboostOptions::GetLogLossBorder(targetOptions);
                     break;

--- a/catboost/cuda/train_lib/pointwise.cpp
+++ b/catboost/cuda/train_lib/pointwise.cpp
@@ -13,5 +13,5 @@ namespace NCatboostCuda {
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorLogloss(GetTrainerFactoryKey(ELossFunction::Logloss));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorCrossEntropy(GetTrainerFactoryKey(ELossFunction::CrossEntropy));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorLq(GetTrainerFactoryKey(ELossFunction::Lq));
-
+    TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorExpectile(GetTrainerFactoryKey(ELossFunction::Expectile));
 }

--- a/catboost/cuda/train_lib/pointwise_non_symmetric.cpp
+++ b/catboost/cuda/train_lib/pointwise_non_symmetric.cpp
@@ -12,7 +12,8 @@ namespace NCatboostCuda {
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorRMSELossguide(GetTrainerFactoryKey(ELossFunction::RMSE, EGrowPolicy::Lossguide));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorLoglossLossguide(GetTrainerFactoryKey(ELossFunction::Logloss, EGrowPolicy::Lossguide));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorCrossEntropyLossguide(GetTrainerFactoryKey(ELossFunction::CrossEntropy, EGrowPolicy::Lossguide));
-
+    TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorExpectileLossguide(GetTrainerFactoryKey(ELossFunction::Expectile, EGrowPolicy::Lossguide));
+    
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorPoissonDepthwise(GetTrainerFactoryKey(ELossFunction::Poisson, EGrowPolicy::Depthwise));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorMapeDepthwise(GetTrainerFactoryKey(ELossFunction::MAPE, EGrowPolicy::Depthwise));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorMaeDepthwise(GetTrainerFactoryKey(ELossFunction::MAE, EGrowPolicy::Depthwise));
@@ -21,6 +22,7 @@ namespace NCatboostCuda {
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorRMSEDepthwise(GetTrainerFactoryKey(ELossFunction::RMSE, EGrowPolicy::Depthwise));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorLoglossDepthwise(GetTrainerFactoryKey(ELossFunction::Logloss, EGrowPolicy::Depthwise));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorCrossEntropyDepthwise(GetTrainerFactoryKey(ELossFunction::CrossEntropy, EGrowPolicy::Depthwise));
+    TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorExpectileDepthwise(GetTrainerFactoryKey(ELossFunction::Expectile, EGrowPolicy::Depthwise));
 
     //    TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorRmseOT(GetTrainerFactoryKey(ELossFunction::RMSE, EGrowPolicy::SymmetricTree));
 

--- a/catboost/cuda/train_lib/pointwise_region.cpp
+++ b/catboost/cuda/train_lib/pointwise_region.cpp
@@ -13,5 +13,5 @@ namespace NCatboostCuda {
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorRMSE(GetTrainerFactoryKeyForRegion(ELossFunction::RMSE));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorLogloss(GetTrainerFactoryKeyForRegion(ELossFunction::Logloss));
     TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorCrossEntropy(GetTrainerFactoryKeyForRegion(ELossFunction::CrossEntropy));
-
+    TGpuTrainerFactory::TRegistrator<TPointwiseTrainer> RegistratorExpectile(GetTrainerFactoryKeyForRegion(ELossFunction::Expectile));
 }

--- a/catboost/libs/algo/error_functions.h
+++ b/catboost/libs/algo/error_functions.h
@@ -258,6 +258,45 @@ private:
     }
 };
 
+class TExpectileError final : public IDerCalcer {
+public:
+    static constexpr double EXPECTILE_DER3 = 0.0;
+
+public:
+    const double Alpha;
+
+public:
+    explicit TExpectileError(bool isExpApprox)
+        : IDerCalcer(isExpApprox)
+        , Alpha(0.5)
+    {
+        CB_ENSURE(isExpApprox == false, "Approx format does not match");
+    }
+
+    TExpectileError(double alpha, bool isExpApprox)
+        : IDerCalcer(isExpApprox)
+        , Alpha(alpha)
+    {
+        Y_ASSERT(Alpha > -1e-6 && Alpha < 1.0 + 1e-6);
+        CB_ENSURE(isExpApprox == false, "Approx format does not match");
+    }
+
+private:
+    double CalcDer(double approx, float target) const override {
+        double e = target - approx;
+        return (e > 0) ? 2.0 * Alpha * e : 2.0 * (1 - Alpha) * e;
+    }
+
+    double CalcDer2(double approx, float target) const override {
+        double e = target - approx;
+        return (e > 0) ? -2.0 * Alpha : -2.0 * (1 - Alpha);
+    }
+
+    double CalcDer3(double /*approx*/, float /*target*/) const override {
+        return EXPECTILE_DER3;
+    }
+};
+
 class TLqError final : public IDerCalcer {
 public:
     const double Q;

--- a/catboost/libs/algo/target_classifier.cpp
+++ b/catboost/libs/algo/target_classifier.cpp
@@ -50,6 +50,7 @@ TTargetClassifier BuildTargetClassifier(TConstArrayRef<float> target,
     switch (loss) {
         case ELossFunction::RMSE:
         case ELossFunction::Quantile:
+        case ELossFunction::Expectile:
         case ELossFunction::Lq:
         case ELossFunction::LogLinQuantile:
         case ELossFunction::Poisson:

--- a/catboost/libs/algo/tensor_search_helpers.cpp
+++ b/catboost/libs/algo/tensor_search_helpers.cpp
@@ -90,6 +90,15 @@ THolder<IDerCalcer> BuildError(
                 return MakeHolder<TQuantileError>(FromString<float>(lossParams.at("alpha")), isStoreExpApprox);
             }
         }
+        case ELossFunction::Expectile: {
+            const auto& lossParams = params.LossFunctionDescription->GetLossParams();
+            if (lossParams.empty()) {
+                return MakeHolder<TExpectileError>(isStoreExpApprox);
+            } else {
+                CB_ENSURE(lossParams.begin()->first == "alpha", "Invalid loss description" << ToString(params.LossFunctionDescription.Get()));
+                return MakeHolder<TExpectileError>(FromString<float>(lossParams.at("alpha")), isStoreExpApprox);
+            }
+        }
         case ELossFunction::LogLinQuantile: {
             const auto& lossParams = params.LossFunctionDescription->GetLossParams();
             if (lossParams.empty()) {

--- a/catboost/libs/documents_importance/ders_helpers.cpp
+++ b/catboost/libs/documents_importance/ders_helpers.cpp
@@ -83,6 +83,8 @@ static TEvaluateDerivativesFunc GetEvaluateDerivativesFunc(ELossFunction lossFun
         case ELossFunction::MAE:
         case ELossFunction::Quantile:
             return EvaluateDerivativesForError<TQuantileError>;
+        case ELossFunction::Expectile:
+            return EvaluateDerivativesForError<TExpectileError>;
         case ELossFunction::LogLinQuantile:
             return EvaluateDerivativesForError<TLogLinQuantileError>;
         case ELossFunction::MAPE:

--- a/catboost/libs/metrics/metric.h
+++ b/catboost/libs/metrics/metric.h
@@ -222,6 +222,8 @@ THolder<IMetric> MakeNumErrorsMetric(double k);
 
 THolder<IMetric> MakeQuantileMetric(ELossFunction lossFunction, double alpha = 0.5);
 
+THolder<IMetric> MakeExpectileMetric(ELossFunction lossFunction, double alpha = 0.5);
+
 THolder<IMetric> MakeLogLinQuantileMetric(double alpha = 0.5);
 
 THolder<IMetric> MakeMAPEMetric();

--- a/catboost/libs/options/catboost_options.cpp
+++ b/catboost/libs/options/catboost_options.cpp
@@ -77,6 +77,13 @@ void NCatboostOptions::TCatBoostOptions::SetLeavesEstimationDefault() {
             defaultEstimationMethod = ELeavesEstimation::Gradient;
             break;
         }
+        case ELossFunction::Expectile: {
+            CB_ENSURE(lossFunctionConfig.GetLossParams().contains("alpha"), "Param alpha is mandatory for expectile loss");
+            defaultNewtonIterations = 5;
+            defaultGradientIterations = 10;
+            defaultEstimationMethod = ELeavesEstimation::Newton;
+            break;            
+        }
         case ELossFunction::PairLogit: {
             defaultEstimationMethod = ELeavesEstimation::Newton;
             defaultNewtonIterations = 10;

--- a/catboost/libs/options/enum_helpers.cpp
+++ b/catboost/libs/options/enum_helpers.cpp
@@ -11,6 +11,7 @@ TConstArrayRef<ELossFunction> GetAllObjectives() {
     static TVector<ELossFunction> allObjectives = {
         ELossFunction::Logloss, ELossFunction::CrossEntropy, ELossFunction::RMSE,
         ELossFunction::MAE, ELossFunction::Quantile, ELossFunction::LogLinQuantile,
+        ELossFunction::Expectile,
         ELossFunction::MAPE, ELossFunction::Poisson, ELossFunction::MultiClass,
         ELossFunction::MultiClassOneVsAll, ELossFunction::PairLogit,
         ELossFunction::PairLogitPairwise, ELossFunction::YetiRank, ELossFunction::YetiRankPairwise,
@@ -156,6 +157,7 @@ bool IsRegressionObjective(ELossFunction lossFunction) {
             lossFunction == ELossFunction::MAPE ||
             lossFunction == ELossFunction::Poisson ||
             lossFunction == ELossFunction::Quantile ||
+            lossFunction == ELossFunction::Expectile ||
             lossFunction == ELossFunction::RMSE ||
             lossFunction == ELossFunction::LogLinQuantile ||
             lossFunction == ELossFunction::Lq ||

--- a/catboost/libs/options/enums.h
+++ b/catboost/libs/options/enums.h
@@ -111,6 +111,7 @@ enum class ELossFunction {
     Lq,
     MAE,
     Quantile,
+    Expectile,
     LogLinQuantile,
     MAPE,
     Poisson,


### PR DESCRIPTION
This pull request implements `expectile` loss, i.e. [Quantile and Expectile Regression Models](https://freakonometrics.hypotheses.org/files/2016/11/causal-esc.pdf). It's very similar to quantile regression, the expectile loss function is |tau-1(u<=0)|.u^2 (compare with |alpha-1(u<=0)|.|u| for quantile regression). For quantile regression when alpha=0.5 the result is MAE, for expectile regression tau=0.5 results in MSE. Unlike quantile regression, the function has non-constant first derivative, and the 2nd derivative exists so can use L'(x)/L''(x) (Newtons method to find the minimum loss)

I used alpha in place of tau as it avoid extra coding, i.e. --loss-function Expectile:alpha=0.5

I've not added any tests yet, but both CPU and GPU appear to work.