### PR TITLE
Fix DeprecationWarning in collections import

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from six import iteritems, string_types, integer_types
 import os
 import imp
-from collections import Iterable, Sequence, Mapping, MutableMapping
+from collections.abc import Iterable, Sequence, Mapping, MutableMapping
 import warnings
 import numpy as np
 import ctypes

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -3,7 +3,12 @@ from copy import deepcopy
 from six import iteritems, string_types, integer_types
 import os
 import imp
-from collections.abc import Iterable, Sequence, Mapping, MutableMapping
+
+if sys.version_info >= (3, 3):
+    from collections.abc import Iterable, Sequence, Mapping, MutableMapping
+else:
+    from collections import Iterable, Sequence, Mapping, MutableMapping
+
 import warnings
 import numpy as np
 import ctypes


### PR DESCRIPTION
"DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working from collections import Iterable, Sequence, Mapping, MutableMapping"

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
