### PR TITLE
Quoting YA_BAT_* commands

### DIFF
--- a/ya.bat
+++ b/ya.bat
@@ -8,13 +8,13 @@ call :dbg Ya: %YA_BAT_REAL%
 call :find_python
 if ERRORLEVEL 1 exit /b 1
 call :dbg Python: %YA_BAT_PYTHON%
-call %YA_BAT_PYTHON% %YA_BAT_REAL% %*
+call %YA_BAT_PYTHON% "%YA_BAT_REAL%" %*
 exit /b %ERRORLEVEL%
 
 :find_ya
 call :dbg Searching for ya near ya.bat...
 set YA_BAT_REAL=%~dp0ya
-if exist %YA_BAT_REAL% exit /b 0
+if exist "%YA_BAT_REAL%" exit /b 0
 call :err Ya not found
 exit /b 1
 


### PR DESCRIPTION
(As requested by @exprmntr in https://github.com/catboost/catboost/pull/728#discussion_r266381744)

Mostly self-explanatory pull request — the only changes made here are added quote marks wrapping commands executed from `ya.bat` file. (This might be helpful if those commands contain spaces — e.g., if the username contains spaces.)

