### PR TITLE
Switch CatBoost reference to __builtin__ method (Python 2) to builtin…

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -2006,11 +2006,10 @@ class CatBoost(_CatBoostBase):
 
         if type == EFstrType.PredictionDiff:
             if data is None and isinstance(data, Pool):
-                try:
-                    import builtins
-                except ImportError:
-                    import __builtin__ as builtins
-                from builtins import type as typeof
+                if sys.version_info[0] >= 3:
+                    from builtins import type as typeof
+                else:
+                    from __builtin__ import type as typeof
                 raise CatBoostError("Invalid data type={}, must be list or np.array".format(typeof(data)))
 
             data, _ = self._process_predict_input_data(data, "get_feature_importance")
@@ -2019,11 +2018,10 @@ class CatBoost(_CatBoostBase):
 
         else:
             if data is not None and not isinstance(data, Pool):
-                try:
-                    import builtins
-                except ImportError:
-                    import __builtin__ as builtins
-                from builtins import type as typeof
+                if sys.version_info[0] >= 3:
+                    from builtins import type as typeof
+                else:
+                    from __builtin__ import type as typeof
                 raise CatBoostError("Invalid data type={}, must be catboost.Pool.".format(typeof(data)))
 
         need_meta_info = type == EFstrType.PredictionValuesChange

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -2006,7 +2006,7 @@ class CatBoost(_CatBoostBase):
 
         if type == EFstrType.PredictionDiff:
             if data is None and isinstance(data, Pool):
-                from __builtin__ import type as typeof
+                from builtins import type as typeof
                 raise CatBoostError("Invalid data type={}, must be list or np.array".format(typeof(data)))
 
             data, _ = self._process_predict_input_data(data, "get_feature_importance")
@@ -2015,7 +2015,7 @@ class CatBoost(_CatBoostBase):
 
         else:
             if data is not None and not isinstance(data, Pool):
-                from __builtin__ import type as typeof
+                from builtins import type as typeof
                 raise CatBoostError("Invalid data type={}, must be catboost.Pool.".format(typeof(data)))
 
         need_meta_info = type == EFstrType.PredictionValuesChange

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -2006,6 +2006,10 @@ class CatBoost(_CatBoostBase):
 
         if type == EFstrType.PredictionDiff:
             if data is None and isinstance(data, Pool):
+                try:
+                    import builtins
+                except ImportError:
+                    import __builtin__ as builtins
                 from builtins import type as typeof
                 raise CatBoostError("Invalid data type={}, must be list or np.array".format(typeof(data)))
 
@@ -2015,6 +2019,10 @@ class CatBoost(_CatBoostBase):
 
         else:
             if data is not None and not isinstance(data, Pool):
+                try:
+                    import builtins
+                except ImportError:
+                    import __builtin__ as builtins
                 from builtins import type as typeof
                 raise CatBoostError("Invalid data type={}, must be catboost.Pool.".format(typeof(data)))
 


### PR DESCRIPTION
I'm in the process of utilizing get_feature_importance with SHAP values. Unfortunately I encounter an error with `core.py` using `__builtin__` which is from Python 2. Considering deprecation, I switched to `builtins`. 

Global standard is shifting from py2 to py3

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.