### PR TITLE
Model shrink rate interaction

### DIFF
--- a/catboost/libs/algo/train.cpp
+++ b/catboost/libs/algo/train.cpp
@@ -87,8 +87,24 @@ static void ScaleAllApproxes(
         *localExecutor,
         0,
         allApproxes.size(),
-        [approxMultiplier, storeExpApprox, learnApproxesCount, localExecutor, &allApproxes](int index) {
+        [approxMultiplier, storeExpApprox, learnApproxesCount, localExecutor, learnProgress, &allApproxes](int index) {
             const bool isLearnApprox = (index < learnApproxesCount);
+            if (learnProgress->StartingApprox) {
+                CB_ENSURE(!storeExpApprox);
+                const double addend = (1 - approxMultiplier) * (*learnProgress->StartingApprox);
+                UpdateApprox(
+                    [approxMultiplier, addend](
+                        TConstArrayRef<double> /* delta */,
+                        TArrayRef<double> approx,
+                        size_t idx)
+                    {
+                        approx[idx] = addend + approx[idx] * approxMultiplier;
+                    },
+                    *allApproxes[index], // stub deltas
+                    allApproxes[index],
+                    localExecutor
+                );
+            }
             if (storeExpApprox && isLearnApprox) {
                 UpdateApprox(
                     [approxMultiplier](TConstArrayRef<double> /* delta */, TArrayRef<double> approx, size_t idx) {

--- a/catboost/libs/options/catboost_options.cpp
+++ b/catboost/libs/options/catboost_options.cpp
@@ -693,6 +693,13 @@ void NCatboostOptions::TCatBoostOptions::SetNotSpecifiedOptionsToDefaults() {
             }
         }
     }
+    if (TaskType == ETaskType::CPU) {
+        if (!ObliviousTreeOptions->MonotoneConstraints->empty() &&
+            !BoostingOptions->ModelShrinkRate.IsSet())
+        {
+            BoostingOptions->ModelShrinkRate = 0.2;
+        }
+    }
 
     SetLeavesEstimationDefault();
     SetCtrDefaults();

--- a/catboost/libs/train_lib/options_helper.cpp
+++ b/catboost/libs/train_lib/options_helper.cpp
@@ -203,14 +203,21 @@ static void UpdateAndValidateMonotoneConstraints(
 
 static void WarnIfBaselineUsedWithModelShrinkage(
     const NCB::TDataMetaInfo& trainDataMetaInfo,
-    NCatboostOptions::TCatBoostOptions* catBoostOptions
+    bool learningContinuation,
+    const NCatboostOptions::TCatBoostOptions* catBoostOptions
 ) {
     if (catBoostOptions->GetTaskType() == ETaskType::CPU) {
-        CB_ENSURE(
-            catBoostOptions->BoostingOptions->ModelShrinkRate.Get() == 0.0f ||
-            trainDataMetaInfo.BaselineCount == 0,
-            "Usage of model_shrink_rate option in combination with baseline column is not implemented yet."
-        );
+        if (catBoostOptions->BoostingOptions->ModelShrinkRate.Get() != 0.0f) {
+            CB_ENSURE(
+                trainDataMetaInfo.BaselineCount == 0,
+                "Usage of model_shrink_rate option in combination with baseline column is not implemented yet."
+            );
+            CB_ENSURE(
+                !learningContinuation,
+                "Usage of model_shrink_rate option in combination with learning continuation is not implemented."
+            );
+        }
+
     }
 }
 
@@ -240,5 +247,5 @@ void SetDataDependentDefaults(
     );
     UpdateLeavesEstimationIterations(trainDataMetaInfo, catBoostOptions);
     UpdateAndValidateMonotoneConstraints(*trainDataMetaInfo.FeaturesLayout.Get(), catBoostOptions);
-    WarnIfBaselineUsedWithModelShrinkage(trainDataMetaInfo, catBoostOptions);
+    WarnIfBaselineUsedWithModelShrinkage(trainDataMetaInfo, learningContinuation, catBoostOptions);
 }

--- a/catboost/libs/train_lib/train_model.cpp
+++ b/catboost/libs/train_lib/train_model.cpp
@@ -676,6 +676,17 @@ namespace {
                 }
             }
 
+            if (catboostOptions.BoostingOptions->ModelShrinkRate.Get() != 0.0f) {
+                CB_ENSURE(!initModel,
+                    "Usage of model_shrink_rate option in combination with learning continuation is unimplemented yet."
+                );
+                auto errMessage = "Usage of model_shrink_rate option in combination with baseline is unimplemented yet.";
+                CB_ENSURE(!trainingDataForCpu.Learn->TargetData->GetBaseline(), errMessage);
+                for (ui32 testIdx = 0; testIdx < trainingDataForCpu.Test.size(); ++testIdx) {
+                    CB_ENSURE(!trainingData.Test[testIdx]->TargetData->GetBaseline(), errMessage);
+                }
+            }
+
             TLearnContext ctx(
                 catboostOptions,
                 objectiveDescriptor,


### PR DESCRIPTION
1. Set default value for model_shrink_rate to 0.2 when monotone constraints is not empty .
2. Reset model_shrink_rate to zero if baseline or init_model is present.
3. Fix shrinkage in combination with boosting from average.