### PR TITLE
Build C++ evaluator without CPU instruction sets optimisations

### DIFF
--- a/build/ymake.core.conf
+++ b/build/ymake.core.conf
@@ -3301,7 +3301,7 @@ SSE_CFLAGS=
 SSE4_DEFINES=
 SSE4_CFLAGS=
 
-when ($ARCH_X86_64 || $ARCH_I386) {
+when (($ARCH_X86_64 || $ARCH_I386) && $DISABLE_INSTRUCTION_SETS != "yes") {
     when ($CLANG || $CLANG_CL || $GCC) {
         SSE2_CFLAGS=-msse2
         SSE3_CFLAGS=-msse3

--- a/catboost/libs/model/cpu/evaluator_impl.cpp
+++ b/catboost/libs/model/cpu/evaluator_impl.cpp
@@ -47,7 +47,7 @@ namespace NCB::NModelEvaluation {
         }
     }
 
-    #ifdef ARCADIA_SSE
+    #ifdef _sse3_
 
     template <bool NeedXorMask, size_t SSEBlockCount, int curTreeSize>
     Y_FORCE_INLINE void CalcIndexesSseDepthed(
@@ -167,7 +167,7 @@ namespace NCB::NModelEvaluation {
         }
     }
 
-    #ifdef ARCADIA_SSE
+    #ifdef _sse3_
     template <int SSEBlockCount>
     Y_FORCE_INLINE static void GatherAddLeafSSE(const double* __restrict treeLeafPtr, const ui8* __restrict indexesPtr, __m128d* __restrict writePtr) {
         _mm_prefetch((const char*)(treeLeafPtr + 64), _MM_HINT_T2);
@@ -265,7 +265,7 @@ namespace NCB::NModelEvaluation {
         ui8* __restrict indexesVec = (ui8*)indexesVecUI32;
         const auto treeLeafPtr = trees.LeafValues.data();
         auto firstLeafOffsetsPtr = trees.GetFirstLeafOffsets().data();
-    #ifdef ARCADIA_SSE
+    #ifdef _sse3_
         bool allTreesAreShallow = AllOf(
             trees.TreeSizes.begin() + treeStart,
             trees.TreeSizes.begin() + treeEnd,
@@ -322,7 +322,7 @@ namespace NCB::NModelEvaluation {
         for (size_t treeId = treeStart; treeId < treeEnd; ++treeId) {
             auto curTreeSize = trees.TreeSizes[treeId];
             memset(indexesVec, 0, sizeof(ui32) * docCountInBlock);
-#ifdef ARCADIA_SSE
+#ifdef _sse3_
             if (!CalcLeafIndexesOnly && curTreeSize <= 8) {
                 CalcIndexesSse<NeedXorMask, SSEBlockCount>(binFeatures, docCountInBlock, indexesVec, treeSplitsCurPtr,
                                                            curTreeSize);

--- a/util/charset/ya.make
+++ b/util/charset/ya.make
@@ -14,7 +14,7 @@ JOIN_SRCS(
     wide.cpp
 )
 
-IF (ARCH_X86_64)
+IF (ARCH_X86_64 AND NOT DISABLE_INSTRUCTION_SETS)
     SRC_CPP_SSE41(wide_sse41.cpp)
 ELSE()
     SRC(


### PR DESCRIPTION
Add ability to build C++ evaluation library without CPU instruction sets optimisations. This allows to evaluate models on any old CPUs. Although our CPUs have SSE3, I think the easiest option at this point is to disable all optimisations.

The following changes were needed:
- detect `DISABLE_INSTRUCTION_SETS` in `ymake.core.conf` and in `util/charset`
- evaluator SSE implementation requires SSE3

I hereby agree to the terms of the CLA available at: [https://yandex.ru/legal/cla/?lang=en].