### PR TITLE
Fix learn error calculation for logloss with monotonic constraints.

### DIFF
--- a/catboost/private/libs/algo/train.cpp
+++ b/catboost/private/libs/algo/train.cpp
@@ -77,8 +77,8 @@ static void ScaleAllApproxes(
         }
     }
     allApproxes.push_back(&learnProgress->AveragingFold.BodyTailArr[0].Approx);
-    allApproxes.push_back(&learnProgress->AvrgApprox);
     const int learnApproxesCount = SafeIntegerCast<int>(allApproxes.size());
+    allApproxes.push_back(&learnProgress->AvrgApprox);
     for (auto& testApprox : learnProgress->TestApprox) {
         allApproxes.push_back(&testApprox);
     }


### PR DESCRIPTION
Fix learn approx update when model shrinkage is on and approxes are exponentiated.