### PR TITLE
Fix for top_size parameter in get_object_importance method

### DIFF
--- a/catboost/private/libs/documents_importance/docs_importance.cpp
+++ b/catboost/private/libs/documents_importance/docs_importance.cpp
@@ -103,8 +103,8 @@ static TDStrResult GetFinalDocumentImportances(
             if (predicate(preprocessedImportancesRef[indices[i]])) {
                 result.Scores[testDocId].push_back(preprocessedImportancesRef[indices[i]]);
                 result.Indices[testDocId].push_back(indices[i]);
-            }
-            ++currentSize;
+                ++currentSize;
+            }            
         }
     }
     return result;


### PR DESCRIPTION
This fixes get_object_importance() returning fewer objects than the parameter top_size value. (#1045)

I hereby agree to the terms of the CLA available at: [https://yandex.ru/legal/cla/?lang=en].

