### PR TITLE
Use environment marker to specify enum34 dependency

### DIFF
--- a/catboost/python-package/setup.py
+++ b/catboost/python-package/setup.py
@@ -27,10 +27,8 @@ install_requires=[
     'scipy',
     'plotly',
     'six',
+    'enum34; python_version < "3.4"'
 ],
-
-if sys.version_info < (3, 4):
-    install_requires.append('enum34')
 
 setup(
     name=PACKAGE,


### PR DESCRIPTION
Use environment markers ([PEP-0508](https://www.python.org/dev/peps/pep-0508/)) for typing_extensions to specify
that enum34 is only required if python < 3.4. Some dependency management
tools (including poetry) only work reliable with environment markers
instead of conditional checks in setup.py.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
