### PR TITLE
Refactor monotone constraint utils

### DIFF
--- a/catboost/private/libs/algo/monotonic_constraint_utils.h
+++ b/catboost/private/libs/algo/monotonic_constraint_utils.h
@@ -28,7 +28,7 @@ TVector<TVector<ui32>> BuildMonotonicLinearOrdersOnLeafs(const TVector<int>& tre
  */
 void CalcOneDimensionalIsotonicRegression(
     const TVector<double>& values,
-    const TVector<double>& weight,
+    const TVector<double>& weights,
     const TVector<ui32>& indexOrder,
     TVector<double>* solution
 );

--- a/catboost/private/libs/algo/ut/monotonic_constraints_ut.cpp
+++ b/catboost/private/libs/algo/ut/monotonic_constraints_ut.cpp
@@ -40,18 +40,18 @@ Y_UNIT_TEST_SUITE(BuildOrderTest) {
             const TVector<int> treeMonotonicConstraints{1, -1};
             UNIT_ASSERT_EQUAL(
                 BuildLinearOrderOnLeafsOfMonotonicSubtree(treeMonotonicConstraints, 0u),
-                (TVector<ui32>{2u, 3u, 0u, 1u})
+                (TVector<ui32>{2u, 0u, 3u, 1u})
             );
         }
         {
             const TVector<int> treeMonotonicConstraints{-1, 0, 1};
             UNIT_ASSERT_EQUAL(
                 BuildLinearOrderOnLeafsOfMonotonicSubtree(treeMonotonicConstraints, 0u),
-                (TVector<ui32>{1u, 0u, 5u, 4u})
+                (TVector<ui32>{1u, 5u, 0u, 4u})
             );
             UNIT_ASSERT_EQUAL(
                 BuildLinearOrderOnLeafsOfMonotonicSubtree(treeMonotonicConstraints, 1u),
-                (TVector<ui32>{3u, 2u, 7u, 6u})
+                (TVector<ui32>{3u, 7u, 2u, 6u})
             );
         }
     }
@@ -59,15 +59,25 @@ Y_UNIT_TEST_SUITE(BuildOrderTest) {
     Y_UNIT_TEST(AllOnes) {
         const size_t treeDepth = 6u;
         const size_t leafCount = 1u << treeDepth;
-        const TVector<int> treeMonotonicConstraints(treeDepth, 1);
         TVector<ui32> expectedOrder(leafCount, 0u);
-        for (ui32 i : xrange<ui32>(leafCount)) {
-            expectedOrder[i] = i;
+        {
+            const TVector<int> treeMonotonicConstraints(treeDepth, 1);
+            for (ui32 i : xrange<ui32>(leafCount)) {
+                expectedOrder[i] = ReverseBits(i, treeDepth);
+            }
+            UNIT_ASSERT_EQUAL(
+                BuildLinearOrderOnLeafsOfMonotonicSubtree(treeMonotonicConstraints, 0u),
+                expectedOrder
+            );
         }
-        UNIT_ASSERT_EQUAL(
-            BuildLinearOrderOnLeafsOfMonotonicSubtree(treeMonotonicConstraints, 0u),
-            expectedOrder
-        );
+        {
+            const TVector<int> treeMonotonicConstraints(treeDepth, -1);
+            Reverse(expectedOrder.begin(), expectedOrder.end());
+            UNIT_ASSERT_EQUAL(
+                BuildLinearOrderOnLeafsOfMonotonicSubtree(treeMonotonicConstraints, 0u),
+                expectedOrder
+            );
+        }
     }
 }
 


### PR DESCRIPTION
There is a change in a behavior: the function BuildLinearOrderOnLeafsOfMonotonicSubtree now builds the order which is consistent with a recursive traversal of a tree, while previous version builds order consistent with traversal of tree with reversed splits.