### PR TITLE
Remove sys/sysctl.h

### DIFF
--- a/util/datetime/cputimer.cpp
+++ b/util/datetime/cputimer.cpp
@@ -13,13 +13,8 @@
 #include <sys/types.h>
 #include <sys/resource.h>
 #include <sys/param.h>
-#if !defined(_cygwin_) && !defined(_android_)
-#include <sys/sysctl.h>
-#endif
-#else
-#if defined(_win_)
+#elif defined(_win_)
 #include <util/system/winint.h>
-#endif
 #endif
 
 TTimer::TTimer(const TStringBuf message) {

--- a/util/system/info.cpp
+++ b/util/system/info.cpp
@@ -28,6 +28,9 @@ static int getloadavg(double* loadavg, int nelem) {
 }
 #elif defined(_unix_) || defined(_darwin_)
 #include <sys/types.h>
+#endif
+
+#if defined(_freebsd_) || defined(_darwin_)
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
The `sys/sysctl.h` file mark as deprecated at glibc 2.30. My build is fail.
```
command /home/thebits/.ya/tools/v3/958916803/bin/clang++ --target=x86_64-linux-gnu -B$OS_SDK_ROOT_RESOURCE_GLOBAL/usr/bin -c -o /home/thebits/.ya/build/build_root/zter/0001f6/util/all_system_1.cpp.pic.o /home/thebits/.ya/build/build_root/zter/0001f6/util/all_system_1.cpp -I/home/thebits/.ya/build/build_root/zter/0001f6 -I/home/thebits/src/catboost -I/home/thebits/src/catboost/contrib/libs/cxxsupp/libcxx/include -I/home/thebits/src/catboost/contrib/libs/cxxsupp/libcxxrt -I/home/thebits/src/catboost/contrib/libs/zlib/include -I/home/thebits/src/catboost/contrib/libs/double-conversion/include -fdebug-prefix-map=/home/thebits/.ya/build/build_root/zter/0001f6=/-B -Xclang -fdebug-compilation-dir -Xclang /tmp -pipe -m64 -O3 -fPIC -fexceptions -W -Wall -Wno-parentheses -Werror -DFAKEID=5020880 -DARCADIA_ROOT=/home/thebits/src/catboost -DARCADIA_BUILD_ROOT=/home/thebits/.ya/build/build_root/zter/0001f6 -D_THREAD_SAFE -D_PTHREADS -D_REENTRANT -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES -D_LARGEFILE_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -DNDEBUG -D__LONG_LONG_SUPPORTED -DSSE_ENABLED=1 -DSSE3_ENABLED=1 -DSSSE3_ENABLED=1 -DSSE41_ENABLED=1 -DSSE42_ENABLED=1 -DPOPCNT_ENABLED=1 -DCX16_ENABLED=1 -DCATBOOST_OPENSOURCE=yes -D_libunwind_ -nostdinc++ -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -std=c++1z -Woverloaded-virtual -Wno-invalid-offsetof -Wno-attributes -Wno-dynamic-exception-spec -Wno-register -Wimport-preprocessor-directive-pedantic -Wno-c++17-extensions -Wno-exceptions -Wno-inconsistent-missing-override -Wno-undefined-var-template -Wno-return-std-move -DCATBOOST_OPENSOURCE=yes -nostdinc++ failed with exit code 1
In file included from /home/thebits/.ya/build/build_root/zter/0001f6/util/all_system_1.cpp:37:
In file included from /home/thebits/src/catboost/util/system/info.cpp:31:
/usr/include/sys/sysctl.h:21:2: error: "The <sys/sysctl.h> header is deprecated and will be removed." [-Werror,-W#warnings]
#warning "The <sys/sysctl.h> header is deprecated and will be removed."
 ^
1 error generated.
Failed
```

I fix this include.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru/