### PR TITLE
add UserPerObjMetric as a regression objective

### DIFF
--- a/catboost/private/libs/options/enum_helpers.cpp
+++ b/catboost/private/libs/options/enum_helpers.cpp
@@ -417,7 +417,8 @@ static const TVector<ELossFunction> RegressionObjectives = {
     ELossFunction::MAPE,
     ELossFunction::Poisson,
     ELossFunction::Lq,
-    ELossFunction::Huber
+    ELossFunction::Huber,
+    ELossFunction::UserPerObjMetric
 };
 
 static const TVector<ELossFunction> MultiRegressionObjectives = {


### PR DESCRIPTION
## PR Objective:
Allow for users to use a custom defined metric as regression objective

## What Changed:
* Added a constant of ELossFunction::UserPerObjMetric to the constants vector holding all the RegressionObjectives
