### PR TITLE
Fix typo in the message about `dictionaryId` and `tokenizerId` #1331

### DIFF
--- a/catboost/private/libs/options/text_processing_options.cpp
+++ b/catboost/private/libs/options/text_processing_options.cpp
@@ -31,7 +31,7 @@ namespace NCatboostOptions {
     void TTextColumnTokenizerOptions::Load(const NJson::TJsonValue& options) {
         {
             const bool wasRead = TJsonFieldHelper<TOption<TString>>::Read(options, &TokenizerId);
-            CB_ENSURE(wasRead, "DictionaryOptions: no tokenizerId was specified");
+            CB_ENSURE(wasRead, "DictionaryOptions: no tokenizer_id was specified");
         }
         TokenizerOptions = JsonToTokenizerOptions(options);
     }
@@ -72,7 +72,7 @@ namespace NCatboostOptions {
     void TTextColumnDictionaryOptions::Load(const NJson::TJsonValue& options) {
         {
             const bool wasRead = TJsonFieldHelper<TOption<TString>>::Read(options, &DictionaryId);
-            CB_ENSURE(wasRead, "DictionaryOptions: no dictionaryId was specified");
+            CB_ENSURE(wasRead, "DictionaryOptions: no dictionary_id was specified");
         }
         JsonToDictionaryOptions(options, &DictionaryOptions.Get());
         JsonToDictionaryBuilderOptions(options, &DictionaryBuilderOptions.Get());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.

Typo was fixed: `dictionary_id` and `tokenizer_id` instead of `dictionaryId` and `tokenizerId`

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Run `ya make` in catboost folder to make sure the code builds.
3. Add tests that test your change.
4. Run tests using `ya make -t -A` command.
5. If you haven't already, complete the [CLA](https://yandex.ru/legal/cla/).
