### PR TITLE
Add ability to use docstrings in estimators

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -3618,9 +3618,6 @@ class CatBoost(_CatBoostBase):
         self._object._convert_oblivious_to_asymmetric()
 
 class CatBoostClassifier(CatBoost):
-
-    _estimator_type = 'classifier'
-
     """
     Implementation of the scikit-learn API for CatBoost classification.
 
@@ -4074,6 +4071,9 @@ class CatBoostClassifier(CatBoost):
     text_processing : dict,
         Text processging description.
     """
+    
+    _estimator_type = 'classifier'
+    
     def __init__(
         self,
         iterations=None,
@@ -4621,9 +4621,6 @@ class CatBoostClassifier(CatBoost):
 
 
 class CatBoostRegressor(CatBoost):
-
-    _estimator_type = 'regressor'
-
     """
     Implementation of the scikit-learn API for CatBoost regression.
 
@@ -4640,6 +4637,9 @@ class CatBoostRegressor(CatBoost):
         'MAPE'
         'Lq:q=value'
     """
+    
+    _estimator_type = 'regressor'
+    
     def __init__(
         self,
         iterations=None,


### PR DESCRIPTION
Added ability to use docstrings in CatBoostClassifier and CatBoostRegressor. The functionality was lost earlier because there was code between the docstrings and the class name.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.