### PR TITLE
Fix bug with reallocation of buffers

### DIFF
--- a/catboost/spark/catboost4j-spark/core/src/main/scala/ai/catboost/spark/DataHelpers.scala
+++ b/catboost/spark/catboost4j-spark/core/src/main/scala/ai/catboost/spark/DataHelpers.scala
@@ -97,6 +97,7 @@ private[spark] class FeaturesColumnStorage (
       javaBuffersUi16(i) = buffersUi16(i).asDirectByteBuffer
       javaBuffersUi16(i).order(java.nio.ByteOrder.nativeOrder)
     }
+    bufferSize = newSize
   }
 
   def addToVisitor(visitor: IQuantizedFeaturesDataVisitor) = {


### PR DESCRIPTION
When reallocating buffers, old bufferSize wasn't changed accidentially, which produces errors with such stacktrace
```
Caused by: java.lang.IndexOutOfBoundsException
    at java.nio.Buffer.checkIndex(Buffer.java:544)
    at java.nio.DirectByteBuffer.put(DirectByteBuffer.java:305)
    at ai.catboost.spark.FeaturesColumnStorage$$anonfun$addRowFeatures$1.apply(DataHelpers.scala:76)
    at ai.catboost.spark.FeaturesColumnStorage$$anonfun$addRowFeatures$1.apply(DataHelpers.scala:75)
    at scala.collection.immutable.Range.foreach(Range.scala:160)
    at ai.catboost.spark.FeaturesColumnStorage.addRowFeatures(DataHelpers.scala:75)
    at ai.catboost.spark.DataHelpers$$anonfun$loadQuantizedDataset$9.apply(DataHelpers.scala:329)
    at ai.catboost.spark.DataHelpers$$anonfun$loadQuantizedDataset$9.apply(DataHelpers.scala:328)
    at ai.catboost.spark.DataHelpers$$anonfun$loadQuantizedDataset$14$$anonfun$apply$5.apply(DataHelpers.scala:443)
    at ai.catboost.spark.DataHelpers$$anonfun$loadQuantizedDataset$14$$anonfun$apply$5.apply(DataHelpers.scala:443)
    at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
    at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
    at ai.catboost.spark.DataHelpers$$anonfun$loadQuantizedDataset$14.apply(DataHelpers.scala:443)
    at ai.catboost.spark.DataHelpers$$anonfun$loadQuantizedDataset$14.apply(DataHelpers.scala:442)
    at scala.collection.Iterator$class.foreach(Iterator.scala:891)
    at scala.collection.AbstractIterator.foreach(Iterator.scala:1334)
    at ai.catboost.spark.DataHelpers$.loadQuantizedDataset(DataHelpers.scala:441)
    at ai.catboost.spark.impl.Worker$.processPartition(Workers.scala:38)
    at ai.catboost.spark.impl.Workers$$anonfun$run$2.apply(Workers.scala:140)
    at ai.catboost.spark.impl.Workers$$anonfun$run$2.apply(Workers.scala:139)
    at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$28.apply(RDD.scala:935)
    at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$28.apply(RDD.scala:935)
    at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2101)
    at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2101)
    at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
    at org.apache.spark.scheduler.Task.run(Task.scala:123)
    at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:408)
    at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
    at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
```

This patch fixes this problem.