### PR TITLE
Match used_ram_limit format

### DIFF
--- a/catboost/spark/catboost4j-spark/core/src/main/scala/ai/catboost/spark/impl/Workers.scala
+++ b/catboost/spark/catboost4j-spark/core/src/main/scala/ai/catboost/spark/impl/Workers.scala
@@ -127,7 +127,7 @@ private[spark] class Workers(
     val executorNativeMemoryLimit = SparkHelpers.getExecutorNativeMemoryLimit(spark)
     if (executorNativeMemoryLimit.isDefined) {
       catBoostJsonParamsForWorkers
-        = catBoostJsonParamsForWorkers ~ ("used_ram_limit" -> executorNativeMemoryLimit.get)
+        = catBoostJsonParamsForWorkers ~ ("used_ram_limit" -> s"${executorNativeMemoryLimit.get / 1024}KB")
     }
 
     val catBoostJsonParamsForWorkersString = compact(catBoostJsonParamsForWorkers)


### PR DESCRIPTION
According to documentation https://catboost.ai/docs/search/?query=used_ram_limit, used_ram_limit is expected to be string with format `<size><measure of information>`, but current implementation sends integer instead of string of required format and produces json deserializing error.

This patch fixes this issue and sets memory limit in <XXX>KB format.