### PR TITLE
Fix warning in lfalloc

### DIFF
--- a/library/cpp/lfalloc/lf_allocX64.h
+++ b/library/cpp/lfalloc/lf_allocX64.h
@@ -1670,7 +1670,7 @@ static void DebugTraceMMgr(const char* pszFormat, ...) // __cdecl
 #ifdef _win_
     OutputDebugStringA(buff);
 #else
-    fprintf(stderr, buff);
+    fputs(buff, stderr);
 #endif
 }
 


### PR DESCRIPTION
Variable format string in fprintf() triggers -Wformat-security warning.
Replace with fputs(), as there's not formatting involved.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.