### PR TITLE
Update R docs

### DIFF
--- a/catboost/R-package/R/catboost.R
+++ b/catboost/R-package/R/catboost.R
@@ -51,20 +51,20 @@ NULL
 #' pool_path <- system.file("extdata", "adult_train.1000", package = "catboost")
 #' cd_path <- system.file("extdata", "adult.cd", package = "catboost")
 #' pool <- catboost.load_pool(pool_path, column_description = cd_path)
-#' head(pool)
+#' print(pool)
 #'
 #' # From matrix
 #' target <- 1
 #' data_matrix <-matrix(runif(18), 6, 3)
 #' pool <- catboost.load_pool(data_matrix[, -target], label = data_matrix[, target])
-#' head(pool)
+#' print(pool)
 #'
 #' # From data.frame
-#' nonsense <- c('A', 'B', 'C')
+#' nonsense <- factor(c('A', 'B', 'C'))
 #' data_frame <- data.frame(value = runif(10), category = nonsense[(1:10) %% 3 + 1])
 #' label = (1:10) %% 2
 #' pool <- catboost.load_pool(data_frame, label = label, cat_features = c(2))
-#' head(pool)
+#' print(pool)
 #'
 #' @export
 catboost.load_pool <- function(data, label = NULL, cat_features = NULL, column_description = NULL,
@@ -1677,8 +1677,14 @@ catboost.save_model <- function(model, model_path,
 #' Possible values:
 #' \itemize{
 #'   \item 'Probability'
+#'   \item 'LogProbability'
 #'   \item 'Class'
 #'   \item 'RawFormulaVal'
+#'   \item 'Exponent'
+#'   \item 'RMSEWithUncertainty'
+#'   \item 'InternalRawFormulaVal'
+#'   \item 'VirtEnsembles'
+#'   \item 'TotalUncertainty'
 #' }
 #'
 #' Default value: 'RawFormulaVal'

--- a/catboost/R-package/man/catboost.load_pool.Rd
+++ b/catboost/R-package/man/catboost.load_pool.Rd
@@ -4,11 +4,23 @@
 \alias{catboost.load_pool}
 \title{Create a dataset}
 \usage{
-catboost.load_pool(data, label = NULL, cat_features = NULL,
-  column_description = NULL, pairs = NULL, delimiter = "\\t",
-  has_header = FALSE, weight = NULL, group_id = NULL,
-  group_weight = NULL, subgroup_id = NULL, pairs_weight = NULL,
-  baseline = NULL, feature_names = NULL, thread_count = -1)
+catboost.load_pool(
+  data,
+  label = NULL,
+  cat_features = NULL,
+  column_description = NULL,
+  pairs = NULL,
+  delimiter = "\\t",
+  has_header = FALSE,
+  weight = NULL,
+  group_id = NULL,
+  group_weight = NULL,
+  subgroup_id = NULL,
+  pairs_weight = NULL,
+  baseline = NULL,
+  feature_names = NULL,
+  thread_count = -1
+)
 }
 \arguments{
 \item{data}{A file path, matrix or data.frame with features.
@@ -69,19 +81,19 @@ Create a dataset from the given file, matrix or data.frame.
 pool_path <- system.file("extdata", "adult_train.1000", package = "catboost")
 cd_path <- system.file("extdata", "adult.cd", package = "catboost")
 pool <- catboost.load_pool(pool_path, column_description = cd_path)
-head(pool)
+print(pool)
 
 # From matrix
 target <- 1
 data_matrix <-matrix(runif(18), 6, 3)
 pool <- catboost.load_pool(data_matrix[, -target], label = data_matrix[, target])
-head(pool)
+print(pool)
 
 # From data.frame
-nonsense <- c('A', 'B', 'C')
+nonsense <- factor(c('A', 'B', 'C'))
 data_frame <- data.frame(value = runif(10), category = nonsense[(1:10) \%\% 3 + 1])
 label = (1:10) \%\% 2
 pool <- catboost.load_pool(data_frame, label = label, cat_features = c(2))
-head(pool)
+print(pool)
 
 }

--- a/catboost/R-package/man/catboost.predict.Rd
+++ b/catboost/R-package/man/catboost.predict.Rd
@@ -4,9 +4,15 @@
 \alias{catboost.predict}
 \title{Apply the model}
 \usage{
-catboost.predict(model, pool, verbose = FALSE,
-  prediction_type = "RawFormulaVal", ntree_start = 0, ntree_end = 0,
-  thread_count = -1)
+catboost.predict(
+  model,
+  pool,
+  verbose = FALSE,
+  prediction_type = "RawFormulaVal",
+  ntree_start = 0,
+  ntree_end = 0,
+  thread_count = -1
+)
 }
 \arguments{
 \item{model}{The model obtained as the result of training.
@@ -27,8 +33,14 @@ Default value: FALSE (not used)}
 Possible values:
 \itemize{
   \item 'Probability'
+  \item 'LogProbability'
   \item 'Class'
   \item 'RawFormulaVal'
+  \item 'Exponent'
+  \item 'RMSEWithUncertainty'
+  \item 'InternalRawFormulaVal'
+  \item 'VirtEnsembles'
+  \item 'TotalUncertainty'
 }
 
 Default value: 'RawFormulaVal'}


### PR DESCRIPTION
This PR updates two particular topics about the R docs:
* It replaces usage of the `pool` object method `head` in the examples which looks like was tried to being used as a slicer or printer, but makes the examples fail due to the method not being able to work with non-numerical columns (hopefully another step towards https://github.com/catboost/catboost/issues/439). Along the way also fixes the example to use R's `factor` for categorical features instead of strings, which are not accepted by catboost.
* It adds missing prediction types to the docs which are accepted by the C++ functions but for some reason were not documented.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en