### PR TITLE
(R) Update C++ handles by reference to avoid redundant copies

### DIFF
--- a/catboost/R-package/R/catboost.R
+++ b/catboost/R-package/R/catboost.R
@@ -415,7 +415,7 @@ print.catboost.Model <- function(x, ...) {
     cat(sprintf("CatBoost model (%d trees)\n", x$tree_count))
     cat(sprintf("Loss function: %s\n", catboost.get_plain_params(x)$loss_function))
     cat(sprintf("Fit to %d features\n", NROW(x$feature_importances)))
-    if (is.null.handle(x$handle))
+    if (is.null.handle(x$cpp_obj$handle))
         cat("(Handle is incomplete)\n")
     return(invisible(x))
 }
@@ -1490,8 +1490,7 @@ catboost.train <- function(learn_pool, test_pool = NULL, params = list()) {
     json_params <- prepare_train_export_parameters(params)
     handle <- .Call("CatBoostFit_R", learn_pool, test_pool, json_params)
     raw <- .Call("CatBoostSerializeModel_R", handle)
-    model <- list(handle = handle, raw = raw)
-    class(model) <- "catboost.Model"
+    model <- create.model.base(handle, raw)
 
     if (catboost._is_oblivious(model)) {
         model$feature_importances <- catboost.get_feature_importance(model, learn_pool)
@@ -1603,22 +1602,17 @@ catboost.sum_models <- function(models, weights = NULL, ctr_merge_policy = 'Inte
     i <- 1L
     modelsVector <- list()
     for (model in models) {
-        if (!inherits(model, "catboost.Model"))
-            stop("Expected catboost.Model, got: ", class(model))
-        if (is.null.handle(model$handle))
-            model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-
-        modelsVector[[i]] <- model$handle
+        catboost.restore_handle(model)
+        modelsVector[[i]] <- model$cpp_obj$handle
         i <- i + 1L
     }
     handle <- .Call("CatBoostSumModels_R", modelsVector, weights, ctr_merge_policy)
     raw <- .Call("CatBoostSerializeModel_R", handle)
-    model <- list(handle = handle, raw = raw)
+    model <- create.model.base(handle, raw)
 
     model$random_seed <- 0
     model$learning_rate <- 0
 
-    class(model) <- "catboost.Model"
     return(model)
 }
 
@@ -1642,8 +1636,7 @@ catboost.load_model <- function(model_path, file_format = "cbm") {
     model_path <- path.expand(model_path)
     handle <- .Call("CatBoostReadModel_R", model_path, file_format)
     raw <- .Call("CatBoostSerializeModel_R", handle)
-    model <- list(handle = handle, raw = raw)
-    class(model) <- "catboost.Model"
+    model <- create.model.base(handle, raw)
     model$tree_count <- catboost.ntrees(model)
     model$learning_rate <- catboost.get_plain_params(model)[['learning_rate']]
     return(model)
@@ -1699,10 +1692,9 @@ catboost.save_model <- function(model, model_path,
     if (!is.null(export_parameters))
         params_string <- jsonlite::toJSON(export_parameters, auto_unbox = TRUE)
 
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
+    catboost.restore_handle(model)
     model_path <- path.expand(model_path)
-    status <- .Call("CatBoostOutputModel_R", model$handle, model_path, file_format, params_string, pool)
+    status <- .Call("CatBoostOutputModel_R", model$cpp_obj$handle, model_path, file_format, params_string, pool)
     return(status)
 }
 
@@ -1757,16 +1749,13 @@ catboost.save_model <- function(model, model_path,
 catboost.predict <- function(model, pool,
                              verbose = FALSE, prediction_type = "RawFormulaVal",
                              ntree_start = 0, ntree_end = 0, thread_count = -1) {
-    if (!inherits(model, "catboost.Model"))
-        stop("Expected catboost.Model, got: ", class(model))
     if (!inherits(pool, "catboost.Pool"))
         stop("Expected catboost.Pool, got: ", class(pool))
     if (is.null.handle(pool))
         stop("Pool object is invalid.")
 
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-    prediction <- .Call("CatBoostPredictMulti_R", model$handle, pool,
+    catboost.restore_handle(model)
+    prediction <- .Call("CatBoostPredictMulti_R", model$cpp_obj$handle, pool,
                         verbose, prediction_type, ntree_start, ntree_end, thread_count)
     if (length(prediction) != nrow(pool)) {
         prediction <- matrix(prediction, nrow = nrow(pool), byrow = TRUE)
@@ -1837,9 +1826,8 @@ catboost.staged_predict <- function(model, pool, verbose = FALSE, prediction_typ
         current_tree_count <<- current_tree_count + eval_period
         if (current_tree_count - eval_period >= ntree_end)
             stop("StopIteration")
-        if (is.null.handle(model$handle))
-            model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-        current_approx <- as.array(.Call("CatBoostPredictMulti_R", model$handle, pool,
+        catboost.restore_handle(model)
+        current_approx <- as.array(.Call("CatBoostPredictMulti_R", model$cpp_obj$handle, pool,
                                          verbose, "RawFormulaVal",
                                          current_tree_count - eval_period,
                                          min(current_tree_count, ntree_end), thread_count))
@@ -1924,9 +1912,8 @@ catboost.get_feature_importance <- function(model, pool = NULL, type = "FeatureI
     if ( (type == "PredictionValuesChange" || type == "FeatureImportance") && is.null(pool) && !is.null(model$feature_importances))
         return(model$feature_importances)
 
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-    importances <- .Call("CatBoostCalcRegularFeatureEffect_R", model$handle, pool, type, thread_count)
+    catboost.restore_handle(model)
+    importances <- .Call("CatBoostCalcRegularFeatureEffect_R", model$cpp_obj$handle, pool, type, thread_count)
 
     if (type == "Interaction") {
         colnames(importances) <- c("feature1_index", "feature2_index", "score")
@@ -2008,8 +1995,6 @@ catboost.get_object_importance <- function(
     thread_count = -1,
     ostr_type = NULL
 ) {
-    if (!inherits(model, "catboost.Model"))
-        stop("Expected catboost.Model, got: ", class(model))
     if (!inherits(pool, "catboost.Pool"))
         stop("Expected catboost.Pool, got: ", class(pool))
     if (!inherits(train_pool, "catboost.Pool"))
@@ -2020,13 +2005,13 @@ catboost.get_object_importance <- function(
         stop("'train_pool' object is invalid.")
     if (top_size < 0 && top_size != -1)
         stop("top_size should be positive integer or -1.")
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
+    catboost.restore_handle(model)
     if (!is.null(ostr_type)) {
         type <- ostr_type
         warning("ostr_type option is deprecated, use type instead")
     }
-    importances <- .Call("CatBoostEvaluateObjectImportances_R", model$handle, pool, train_pool, top_size, type, update_method, thread_count)
+    importances <- .Call("CatBoostEvaluateObjectImportances_R", model$cpp_obj$handle,
+                         pool, train_pool, top_size, type, update_method, thread_count)
     indices <- head(importances, length(importances) / 2)
     scores <- tail(importances, length(importances) / 2)
     column_count <- nrow(train_pool)
@@ -2051,15 +2036,12 @@ catboost.get_object_importance <- function(
 #' @export
 #' @seealso \url{https://catboost.ai/docs/concepts/r-reference_catboost-shrink.html}
 catboost.shrink <- function(model, ntree_end, ntree_start = 0) {
-    if (!inherits(model, "catboost.Model"))
-        stop("Expected catboost.Model, got: ", class(model))
     if (ntree_start > ntree_end)
         stop("ntree_start should be less than ntree_end.")
 
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-    status <- .Call("CatBoostShrinkModel_R", model$handle, ntree_start, ntree_end)
-    model$raw <- .Call("CatBoostSerializeModel_R", model$handle)
+    catboost.restore_handle(model)
+    status <- .Call("CatBoostShrinkModel_R", model$cpp_obj$handle, ntree_start, ntree_end)
+    model$cpp_obj$raw <- .Call("CatBoostSerializeModel_R", model$cpp_obj$handle)
     return(status)
 }
 
@@ -2074,33 +2056,23 @@ catboost.shrink <- function(model, ntree_end, ntree_start = 0) {
 #' @return Status, the result of dropping feature. TRUE if this succeeded, FALSE otherwise.
 #' @export
 catboost.drop_unused_features <- function(model, ntree_end, ntree_start = 0) {
-    if (!inherits(model, "catboost.Model"))
-        stop("Expected catboost.Model, got: ", class(model))
-
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-    status <- .Call("CatBoostDropUnusedFeaturesFromModel_R", model$handle)
-    model$raw <- .Call("CatBoostSerializeModel_R", model$handle)
+    catboost.restore_handle(model)
+    status <- .Call("CatBoostDropUnusedFeaturesFromModel_R", model$cpp_obj$handle)
+    model$cpp_obj$raw <- .Call("CatBoostSerializeModel_R", model$cpp_obj$handle)
     return(status)
 }
 
 
 catboost.ntrees <- function(model) {
-    if (!inherits(model, "catboost.Model"))
-        stop("Expected catboost.Model, got: ", class(model))
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-    num_trees <- .Call("CatBoostGetNumTrees_R", model$handle)
+    catboost.restore_handle(model)
+    num_trees <- .Call("CatBoostGetNumTrees_R", model$cpp_obj$handle)
     return(num_trees)
 }
 
 
 catboost._is_oblivious <- function(model) {
-    if (!inherits(model, "catboost.Model"))
-        stop("Expected catboost.Model, got: ", class(model))
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-    is_oblivious <- .Call("CatBoostIsOblivious_R", model$handle)
+    catboost.restore_handle(model)
+    is_oblivious <- .Call("CatBoostIsOblivious_R", model$cpp_obj$handle)
     return(is_oblivious)
 }
 
@@ -2116,11 +2088,8 @@ catboost._is_oblivious <- function(model) {
 #' @export
 #' @seealso \url{https://catboost.ai/docs/concepts/r-reference_catboost-get_model_params.html}
 catboost.get_model_params <- function(model) {
-    if (!inherits(model, "catboost.Model"))
-        stop("Expected catboost.Model, got: ", class(model))
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-    params <- .Call("CatBoostGetModelParams_R", model$handle)
+    catboost.restore_handle(model)
+    params <- .Call("CatBoostGetModelParams_R", model$cpp_obj$handle)
     params <- jsonlite::fromJSON(params)
     return(params)
 }
@@ -2134,11 +2103,8 @@ catboost.get_model_params <- function(model) {
 #' @return A list object with model parameters.
 #' @export
 catboost.get_plain_params <- function(model) {
-    if (!inherits(model, "catboost.Model"))
-        stop("Expected catboost.Model, got: ", class(model))
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
-    params <- .Call("CatBoostGetPlainParams_R", model$handle)
+    catboost.restore_handle(model)
+    params <- .Call("CatBoostGetPlainParams_R", model$cpp_obj$handle)
     params <- jsonlite::fromJSON(params)
     return(params)
 }
@@ -2167,12 +2133,18 @@ catboost.get_plain_params <- function(model) {
 catboost.restore_handle <- function(model) {
     if (!inherits(model, "catboost.Model"))
         stop("Expected catboost.Model, got: ", class(model))
-    if (is.null.handle(model$handle))
-        model$handle <- .Call("CatBoostDeserializeModel_R", model$raw)
+    if (is.null.handle(model$cpp_obj$handle))
+        model$cpp_obj$handle <- .Call("CatBoostDeserializeModel_R", model$cpp_obj$raw)
     return(model)
 }
 
 is.null.handle <- function(handle) {
   stopifnot(typeof(handle) == "externalptr")
   .Call("CatBoostIsNullHandle_R", handle)
+}
+
+create.model.base <- function(handle, raw) {
+    model <- list(cpp_obj = as.environment(list(handle = handle, raw = raw)))
+    class(model) <- "catboost.Model"
+    return(model)
 }


### PR DESCRIPTION
This PR changes the structure used behind the pointers to C++ objects, from an R list (copy-on-write) to an R environment (pass-by-reference).

Currently, as it uses a list with copy-on-modify semantics, when a model object has a reference to a null pointer (happens after restarting an R session or de-serializing an object through R's own functions) and the C++ object is reconstructed from the serialized bytes, it will reconstruct the object in a local environment, which makes it short lived as it doesn't update the original object outside of the function being called, having to reconstruct the object at each successive function call (which is slow and causes extra memory usage).

After the changes, it will only need to de-serialize the C++ object once, as the original object will have a pointer that is updated by reference. It also avoids potential segfaults if the user calls a function that modifies the C++ object but does not re-assign the result to the model object holder from outside.

The changes also allow shortening a bit the R source code as it can call a single function to check the model class and validity of the pointer instead of having to copy-paste the same code over and over.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en