### PR TITLE
[node-package] Handle a call to predict() on not loaded model 

### DIFF
--- a/catboost/node-package/bindings/tests/model.ts
+++ b/catboost/node-package/bindings/tests/model.ts
@@ -106,4 +106,10 @@ function testLoadNonExistentOnConstruction() {
 }
 assert.throws(testLoadNonExistentOnConstruction);
 
+function testPredictOnEmptyModel() {
+    const model = new Model();
+    model.predict([[10.0]], [["a"]]);
+}
+assert.throws(testPredictOnEmptyModel);
+
 console.log("Model tests passed")

--- a/catboost/node-package/src/api_helpers.h
+++ b/catboost/node-package/src/api_helpers.h
@@ -13,32 +13,37 @@
 
 namespace NHelper {
 
-// Checks if the condition is true, throws JS exception otherwise.
-inline void Check(Napi::Env env, bool condition, const std::string& message) {
+// Checks if the condition is true, schedules JS exception otherwise.
+// Returns false if check failed.
+inline bool Check(Napi::Env env, bool condition, const std::string& message) {
     if (!condition) {
         Napi::TypeError::New(env, message)
 	    .ThrowAsJavaScriptException();
     }
+
+    return condition;
 }
 
 // Checks if the pointer is not null, throws JS exception otherwise.
 template <typename T>
-inline void CheckNotNull(Napi::Env env, T* ptr, const std::string& message) {
-    Check(env, ptr != nullptr, message);
+inline bool CheckNotNull(Napi::Env env, T* ptr, const std::string& message) {
+    return Check(env, ptr != nullptr, message);
 }
 
 // Checks that the model handle is not null. As this should never be the case throws internal error.
-inline void CheckNotNullHandle(Napi::Env env, ModelCalcerHandle* handle) {
+inline bool CheckNotNullHandle(Napi::Env env, ModelCalcerHandle* handle) {
     return CheckNotNull(env, handle, "Internal error - null handle encountered");
 }
 
 // Checks that the return status of C API is true, returns error in JS exception otherwise.
-inline void CheckStatus(Napi::Env& env, bool status) {
+inline bool CheckStatus(Napi::Env& env, bool status) {
     if (!status) {
         const char* errorMessage = GetErrorString();
         CheckNotNull(env, errorMessage, "Internal error - error message expected, but missing");
         Napi::Error::New(env, errorMessage).ThrowAsJavaScriptException();
     }
+
+    return status;
 }
 
 // Matrix types in N-API

--- a/catboost/node-package/src/model.cpp
+++ b/catboost/node-package/src/model.cpp
@@ -36,6 +36,9 @@ TModel::TModel(const Napi::CallbackInfo& info): Napi::ObjectWrap<TModel>(info) {
     // The C++ object is considered to be successfully created and will be destoryed by Node runtime
     // later as usual.
     NHelper::CheckStatus(env, status);
+    if (status) {
+        this->ModelLoaded = true;
+    }
 }
 
 TModel::~TModel() {
@@ -66,14 +69,20 @@ void TModel::LoadFullFromFile(const Napi::CallbackInfo& info) {
     const bool status = LoadFullModelFromFile(this->Handle,
                                               info[0].As<Napi::String>().Utf8Value().c_str());
     NHelper::CheckStatus(env, status);
+    if (status) {
+        this->ModelLoaded = true;
+    }
 }
 
 Napi::Value TModel::CalcPrediction(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
 
-    NHelper::Check(env, info.Length() >= 2, "Wrong number of arguments - expected 2");
-    NHelper::Check(env, NHelper::IsMatrix(info[0], NHelper::NAT_NUMBER),
-        "Expected the first argument to be a matrix of floats");
+    if (!NHelper::Check(env, info.Length() >= 2, "Wrong number of arguments - expected 2") ||
+        !NHelper::Check(env, NHelper::IsMatrix(info[0], NHelper::NAT_NUMBER),
+            "Expected the first argument to be a matrix of floats")  ||
+        !NHelper::Check(env, this->ModelLoaded, "Trying to predict from the empty model")) {
+        return env.Undefined();
+    }
 
     const Napi::Array floatFeatures = info[0].As<Napi::Array>();
     const uint32_t docsCount = floatFeatures.Length();
@@ -93,13 +102,17 @@ Napi::Value TModel::CalcPrediction(const Napi::CallbackInfo& info) {
         }
     }
 
-    NHelper::Check(env,
-        NHelper::IsMatrix(info[1], NHelper::NAT_NUMBER) || NHelper::IsMatrix(info[1], NHelper::NAT_STRING),
-        "Expected second argument to be a matrix of strings or numbers");
+    if (!NHelper::Check(env, NHelper::IsMatrix(info[1], NHelper::NAT_NUMBER) ||
+            NHelper::IsMatrix(info[1], NHelper::NAT_STRING),
+            "Expected second argument to be a matrix of strings or numbers")) {
+        return env.Undefined();
+    }
     const Napi::Array catFeatures = info[1].As<Napi::Array>();
 
-    NHelper::Check(env, catFeatures.Length() == docsCount,
-        "Expected the number of docs to be the same for both float and categorial features");
+    if (!NHelper::Check(env, catFeatures.Length() == docsCount,
+        "Expected the number of docs to be the same for both float and categorial features")) {
+        return env.Undefined();
+    }
     const Napi::Array catRow = catFeatures[0u].As<Napi::Array>();
     if (catRow.Length() == 0 || catRow[0u].IsNumber()) {
         return CalcPredictionHash(env, floatFeatureValues, catFeatures);
@@ -192,11 +205,13 @@ Napi::Array TModel::CalcPredictionString(Napi::Env env,
     TVector<const float*> floatPtrs = CollectMatrixRowPointers<float>(floatFeatures, floatFeaturesSize);
     TVector<const char**> catPtrs = CollectMatrixRowPointers<const char*, const char**>(catStringValues, catFeaturesSize);
 
-    NHelper::CheckStatus(env,
-        CalcModelPrediction(this->Handle, docsCount,
+    if (!NHelper::CheckStatus(env,
+            CalcModelPrediction(this->Handle, docsCount,
                         floatPtrs.data(), floatFeaturesSize,
                         catPtrs.data(), catFeaturesSize,
-                        resultValues.data(), docsCount));
+                        resultValues.data(), docsCount))) {
+        return Napi::Array::New(env);
+    }
 
     return NHelper::ConvertToArray(env, resultValues);
 }

--- a/catboost/node-package/src/model.cpp
+++ b/catboost/node-package/src/model.cpp
@@ -62,8 +62,10 @@ Napi::Function TModel::GetClass(Napi::Env env) {
 void TModel::LoadFullFromFile(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
 
-    NHelper::Check(env, info.Length() >= 1, "Wrong number of arguments");
-    NHelper::Check(env, info[0].IsString(), "File name string is required");
+    if (!NHelper::Check(env, info.Length() >= 1, "Wrong number of arguments") ||
+        !NHelper::Check(env, info[0].IsString(), "File name string is required")) {
+        return;
+    }
 
     NHelper::CheckNotNullHandle(env, this->Handle);
     const bool status = LoadFullModelFromFile(this->Handle,

--- a/catboost/node-package/src/model.h
+++ b/catboost/node-package/src/model.h
@@ -30,6 +30,7 @@ public:
 
 private:
     ModelCalcerHandle* Handle = nullptr;
+    bool ModelLoaded = false;
 
     Napi::Array CalcPredictionHash(Napi::Env env,
                                    const TVector<float>& floatFeatures,


### PR DESCRIPTION
1. Fixing a bug where calling predict() on the empty model that hasn't been loaded results in the infinite loop execution.
2. More careful error-handling: NHelper::Check... checks were only scheduling the exception without interrupting the flow of execution, which in turn could cause UB. Handling the result of the checks and returning early. Why C-like (or go-like?) error handling instead of using some custom exception? Node package has to be built on each host that would like to install it, so every client should have a compiler version capable of compiling the bindings. Catboost exceptions make use of C++17 features and not work well with some common compilers (like GCC), so it is much safer to add a couple of if statements.