### PR TITLE
Explicitly specify WHEEL 'Root-Is-Purelib' value

### DIFF
--- a/catboost/python-package/catboost.dist-info/WHEEL
+++ b/catboost/python-package/catboost.dist-info/WHEEL
@@ -1,1 +1,2 @@
 Wheel-Version: 1.0
+Root-Is-Purelib: false


### PR DESCRIPTION
Version `0.25.1` (latest) has the following WHEEL file: 

```bash
cat catboost-0.25.1.dist-info/WHEEL                                                                                                                                                                                                                                                                                 
Wheel-Version: 1.0
```

This causes problems for package installation code that assumes the `Root-Is-Purelib` key is present in the WHEEL. An example is this bug: https://github.com/bazelbuild/rules_python/issues/435.

The `Root-Is-Purelib` key is described in ["PEP-0427-- The Wheel Binary Package Format 1.0"](https://www.python.org/dev/peps/pep-0427/#id14).

Now there's certainly an argument to be made that the `Root-Is-Purelib` is not mandatory and its absence shouldn't be an error, but in any case it's good to be explicit.
