### PR TITLE
[R] Fix memory safety issues

### DIFF
--- a/catboost/R-package/src/catboostr.cpp
+++ b/catboost/R-package/src/catboostr.cpp
@@ -30,32 +30,68 @@
 #include <util/system/info.h>
 
 #include <algorithm>
+#include <cstdio>
 
 #if defined(SIZEOF_SIZE_T)
 #undef SIZEOF_SIZE_T
 #endif
 
+#include <R.h>
 #include <Rinternals.h>
-
 
 using namespace NCB;
 
 
+#define MAXLEN_R_ERRMSG 1024
+char buffer_R_errmsg[MAXLEN_R_ERRMSG];
+void copy_exception_msg_to_buffer(std::exception &e) {
+    std::snprintf(buffer_R_errmsg, MAXLEN_R_ERRMSG, "%s\n", e.what());
+}
+
+struct CB_R_ERROR {SEXP uw_token;};
+
+void loggingFunc(const char* str, size_t len, TCustomLoggingObject) {
+    TString slicedStr(str, 0, len);
+    Rprintf("%s", slicedStr.c_str());
+    R_FlushConsole();
+}
+
+void loggingErrFunc(const char* str, size_t len, TCustomLoggingObject) {
+    TString slicedStr(str, 0, len);
+    REprintf("%s", slicedStr.c_str());
+    R_FlushConsole();
+}
+
+class CB_R_context {
+public:
+    CB_R_context() {
+        SetCustomLoggingFunction(loggingFunc, loggingErrFunc);
+    }
+
+    ~CB_R_context() {
+        RestoreOriginalLogger();
+    }
+};
+
 #define R_API_BEGIN()                                                           \
-    auto loggingFunc = [](const char* str, size_t len, TCustomLoggingObject) {  \
-        TString slicedStr(str, 0, len);                                         \
-        Rprintf("%s", slicedStr.c_str());                                       \
-    };                                                                          \
-    SetCustomLoggingFunction(loggingFunc, loggingFunc);                         \
-    *Singleton<TRPackageInitializer>();                                         \
+    bool threw_error = false;                                                   \
     try {                                                                       \
+    *Singleton<TRPackageInitializer>();                                         \
+    CB_R_context context_manager;                                               \
 
 
 #define R_API_END()                                                 \
     } catch (std::exception& e) {                                   \
-        error(e.what());                                            \
+        copy_exception_msg_to_buffer(e);                            \
+        threw_error = true;                                         \
+    } catch (CB_R_ERROR &err_token) {                               \
+        R_ContinueUnwind(err_token.uw_token);                       \
+    } catch (...) {                                                 \
+        std::sprintf(buffer_R_errmsg, "%s\n", "Unexpected error");  \
+        threw_error = true;                                         \
     }                                                               \
-    RestoreOriginalLogger();                                        \
+    if (threw_error) Rf_error(buffer_R_errmsg);                     \
+    return R_NilValue;                                              \
 
 #if defined(_WIN32)
 #define EXPORT_FUNCTION __declspec(dllexport) SEXP
@@ -70,13 +106,95 @@ typedef TFullModel* TFullModelHandle;
 typedef std::unique_ptr<TFullModel> TFullModelPtr;
 typedef const TFullModel* TFullModelConstPtr;
 
-
 class TRPackageInitializer {
     Y_DECLARE_SINGLETON_FRIEND();
     TRPackageInitializer() {
         ConfigureMalloc();
     }
 };
+
+void safe_R_error(void *ptr_uw_token, Rboolean jump) {
+    if (jump) {
+        throw CB_R_ERROR{*static_cast<SEXP*>(ptr_uw_token)};
+    }
+}
+
+SEXP wrapped_R_VECSXP(void *ptr_size) {
+    return Rf_allocVector(VECSXP, *static_cast<R_xlen_t*>(ptr_size));
+}
+
+SEXP wrapped_R_REALSXP(void *ptr_size) {
+    return Rf_allocVector(REALSXP, *static_cast<R_xlen_t*>(ptr_size));
+}
+
+SEXP wrapped_R_STRSXPSXP(void *ptr_size) {
+    return Rf_allocVector(STRSXP, *static_cast<R_xlen_t*>(ptr_size));
+}
+
+SEXP wrapped_R_RAWSXP(void *ptr_size) {
+    return Rf_allocVector(RAWSXP, *static_cast<R_xlen_t*>(ptr_size));
+}
+
+SEXP wrapped_R_INTSXP(void *ptr_size) {
+    return Rf_allocVector(INTSXP, *static_cast<R_xlen_t*>(ptr_size));
+}
+
+SEXP wrapped_R_LGLSXPSXP(void *ptr_size) {
+    return Rf_allocVector(LGLSXP, *static_cast<R_xlen_t*>(ptr_size));
+}
+
+SEXP safe_R_vector(int Rtype, R_xlen_t size, SEXP &uw_token) {
+    switch (Rtype) {
+        case VECSXP:
+            return R_UnwindProtect(wrapped_R_VECSXP, static_cast<void*>(&size),
+                                   safe_R_error, &uw_token, uw_token);
+        case REALSXP:
+            return R_UnwindProtect(wrapped_R_REALSXP, static_cast<void*>(&size),
+                                   safe_R_error, &uw_token, uw_token);
+        case STRSXP:
+            return R_UnwindProtect(wrapped_R_STRSXPSXP, static_cast<void*>(&size),
+                                   safe_R_error, &uw_token, uw_token);
+        case RAWSXP:
+            return R_UnwindProtect(wrapped_R_RAWSXP, static_cast<void*>(&size),
+                                   safe_R_error, &uw_token, uw_token);
+        case INTSXP:
+            return R_UnwindProtect(wrapped_R_INTSXP, static_cast<void*>(&size),
+                                   safe_R_error, &uw_token, uw_token);
+        case LGLSXP:
+            return R_UnwindProtect(wrapped_R_LGLSXPSXP, static_cast<void*>(&size),
+                                   safe_R_error, &uw_token, uw_token);
+        default:
+            throw std::runtime_error("Unexpected error.");
+            return R_NilValue;
+    }
+}
+
+SEXP wrapped_mkChar(void *txt) {
+    return Rf_mkChar(*static_cast<const char**>(txt));
+}
+
+SEXP safe_R_mkChar(const char* txt, SEXP &uw_token) {
+    return R_UnwindProtect(wrapped_mkChar, static_cast<void*>(&txt),
+                           safe_R_error, &uw_token, uw_token);
+}
+
+SEXP wrapped_asChar(void *R_obj) {
+    return Rf_asChar(*static_cast<SEXP*>(R_obj));
+}
+
+SEXP safe_R_asChar(SEXP R_obj, SEXP &uw_token) {
+    return R_UnwindProtect(wrapped_asChar, static_cast<void*>(&R_obj),
+                           safe_R_error, &uw_token, uw_token);
+}
+
+SEXP wrapped_mkString(void *txt) {
+    return Rf_mkString(*static_cast<const char**>(txt));
+}
+
+SEXP safe_R_mkString(const char *txt, SEXP &uw_token) {
+    return R_UnwindProtect(wrapped_mkString, static_cast<void*>(&txt),
+                           safe_R_error, &uw_token, uw_token);
+}
 
 template <typename T>
 void _Finalizer(SEXP ext) {
@@ -106,8 +224,8 @@ static TVector<T> GetVectorFromSEXP(SEXP arg) {
     return result;
 }
 
-static NJson::TJsonValue LoadFitParams(SEXP fitParamsAsJson) {
-    TString paramsStr(CHAR(asChar(fitParamsAsJson)));
+static NJson::TJsonValue LoadFitParams(const char *fitParamsAsJson) {
+    TString paramsStr(fitParamsAsJson);
     TStringInput is(paramsStr);
     NJson::TJsonValue result;
     NJson::ReadJsonTree(&is, &result);
@@ -132,27 +250,34 @@ EXPORT_FUNCTION CatBoostCreateFromFile_R(SEXP poolFileParam,
                               SEXP hasHeaderParam,
                               SEXP threadCountParam,
                               SEXP verboseParam) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
+    SEXP result = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
     R_API_BEGIN();
+    SEXP delimiterParam_char = PROTECT(safe_R_asChar(delimiterParam, uw_token));
+    SEXP numVectorDelimiterParam_char = PROTECT(safe_R_asChar(numVectorDelimiterParam, uw_token));
 
     NCatboostOptions::TColumnarPoolFormatParams columnarPoolFormatParams;
     columnarPoolFormatParams.DsvFormat =
         TDsvFormatOptions{
             static_cast<bool>(asLogical(hasHeaderParam)),
-            CHAR(asChar(delimiterParam))[0],
-            CHAR(asChar(numVectorDelimiterParam))[0]
+            CHAR(delimiterParam_char)[0],
+            CHAR(numVectorDelimiterParam_char)[0]
         };
 
-    TStringBuf cdPathWithScheme(CHAR(asChar(cdFileParam)));
+    SEXP cdFileParam_char = PROTECT(safe_R_asChar(cdFileParam, uw_token));
+    TStringBuf cdPathWithScheme(CHAR(cdFileParam_char));
     if (!cdPathWithScheme.empty()) {
         columnarPoolFormatParams.CdFilePath = TPathWithScheme(cdPathWithScheme, "dsv");
     }
 
-    TStringBuf pairsPathWithScheme(CHAR(asChar(pairsFileParam)));
-    TStringBuf featureNamesPathWithScheme(CHAR(asChar(featureNamesFileParam)));
+    SEXP pairsFileParam_char = PROTECT(safe_R_asChar(pairsFileParam, uw_token));
+    SEXP featureNamesFileParam_char = PROTECT(safe_R_asChar(featureNamesFileParam, uw_token));
+    TStringBuf pairsPathWithScheme(CHAR(pairsFileParam_char));
+    TStringBuf featureNamesPathWithScheme(CHAR(featureNamesFileParam_char));
+    SEXP poolFileParam_char = PROTECT(safe_R_asChar(poolFileParam, uw_token));
 
     TDataProviderPtr poolPtr = ReadDataset(/*taskType*/Nothing(),
-                                           TPathWithScheme(CHAR(asChar(poolFileParam)), "dsv"),
+                                           TPathWithScheme(CHAR(poolFileParam_char), "dsv"),
                                            !pairsPathWithScheme.empty() ?
                                                TPathWithScheme(pairsPathWithScheme, "dsv-flat") : TPathWithScheme(),
                                            /*groupWeightsFilePath=*/TPathWithScheme(),
@@ -167,12 +292,12 @@ EXPORT_FUNCTION CatBoostCreateFromFile_R(SEXP poolFileParam,
                                            UpdateThreadCount(asInteger(threadCountParam)),
                                            asLogical(verboseParam),
                                            /*classLabels=*/Nothing());
-    result = PROTECT(R_MakeExternalPtr(poolPtr.Get(), R_NilValue, R_NilValue));
+    R_SetExternalPtrAddr(result, poolPtr.Get());
     R_RegisterCFinalizerEx(result, _Finalizer<TPoolHandle>, TRUE);
     Y_UNUSED(poolPtr.Release());
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(8);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostCreateFromMatrix_R(SEXP floatAndCatMatrixParam,
@@ -188,7 +313,9 @@ EXPORT_FUNCTION CatBoostCreateFromMatrix_R(SEXP floatAndCatMatrixParam,
                                 SEXP pairsWeightParam,
                                 SEXP baselineParam,
                                 SEXP featureNamesParam) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
+    SEXP result = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+    size_t n_protected = 2;
     R_API_BEGIN();
     SEXP dataDim = floatAndCatMatrixParam != R_NilValue ?
                    getAttrib(floatAndCatMatrixParam, R_DimSymbol) :
@@ -220,7 +347,9 @@ EXPORT_FUNCTION CatBoostCreateFromMatrix_R(SEXP floatAndCatMatrixParam,
         TVector<TString> featureId;
         if (featureNamesParam != R_NilValue) {
             for (size_t i = 0; i < dataColumns; ++i) {
-                featureId.push_back(CHAR(asChar(VECTOR_ELT(featureNamesParam, i))));
+                SEXP temp = PROTECT(safe_R_asChar(VECTOR_ELT(featureNamesParam, i), uw_token));
+                n_protected++;
+                featureId.push_back(CHAR(temp));
             }
         }
 
@@ -348,52 +477,57 @@ EXPORT_FUNCTION CatBoostCreateFromMatrix_R(SEXP floatAndCatMatrixParam,
 
     TDataProviderPtr poolPtr = CreateDataProvider(std::move(loaderFunc));
 
-    result = PROTECT(R_MakeExternalPtr(poolPtr.Get(), R_NilValue, R_NilValue));
+    R_SetExternalPtrAddr(result, poolPtr.Get());
     R_RegisterCFinalizerEx(result, _Finalizer<TPoolHandle>, TRUE);
     Y_UNUSED(poolPtr.Release());
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(n_protected);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostHashStrings_R(SEXP stringsParam) {
    SEXP result = PROTECT(allocVector(REALSXP, length(stringsParam)));
+   R_API_BEGIN();
    double *ptr_result = REAL(result);
    for (int i = 0; i < length(stringsParam); ++i) {
        ptr_result[i] = static_cast<double>(ConvertCatFeatureHashToFloat(CalcCatFeatureHash(TString(CHAR(STRING_ELT(stringsParam, i))))));
    }
    UNPROTECT(1);
    return result;
+   R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostPoolNumRow_R(SEXP poolParam) {
-    SEXP result = NULL;
+    SEXP result = PROTECT(Rf_allocVector(INTSXP, 1));
     R_API_BEGIN();
     TPoolHandle pool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(poolParam));
-    result = ScalarInteger(static_cast<int>(pool->ObjectsGrouping->GetObjectCount()));
-    R_API_END();
+    INTEGER(result)[0] = static_cast<int>(pool->ObjectsGrouping->GetObjectCount());
+    UNPROTECT(1);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostPoolNumCol_R(SEXP poolParam) {
-    SEXP result = NULL;
+    SEXP result = PROTECT(Rf_allocVector(INTSXP, 1));
+    INTEGER(result)[0] = 0;
     R_API_BEGIN();
     TPoolHandle pool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(poolParam));
-    result = ScalarInteger(0);
     if (pool->ObjectsGrouping->GetObjectCount() != 0) {
-        result = ScalarInteger(static_cast<int>(pool->MetaInfo.GetFeatureCount()));
+        INTEGER(result)[0] = static_cast<int>(pool->MetaInfo.GetFeatureCount());
     }
-    R_API_END();
+    UNPROTECT(1);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostGetNumTrees_R(SEXP modelParam) {
-    SEXP result = NULL;
+    SEXP result = PROTECT(Rf_allocVector(INTSXP, 1));
     R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
-    result = ScalarInteger(static_cast<int>(model->GetTreeCount()));
-    R_API_END();
+    INTEGER(result)[0] = static_cast<int>(model->GetTreeCount());
+    UNPROTECT(1);
     return result;
+    R_API_END();
 }
 
 // TODO(dbakshee): remove this backward compatibility gag in v0.11
@@ -402,18 +536,19 @@ EXPORT_FUNCTION CatBoostPoolNumTrees_R(SEXP modelParam) {
 }
 
 EXPORT_FUNCTION CatBoostIsOblivious_R(SEXP modelParam) {
-    SEXP result = NULL;
+    SEXP result = PROTECT(Rf_allocVector(LGLSXP, 1));
     R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
-    result = ScalarLogical(static_cast<int>(model->IsOblivious()));
-    R_API_END();
+    LOGICAL(result)[0] = static_cast<int>(model->IsOblivious());
+    UNPROTECT(1);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostPoolSlice_R(SEXP poolParam, SEXP sizeParam, SEXP offsetParam) {
-    SEXP result = NULL;
-    size_t size, offset;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
+    size_t size, offset;
     size = static_cast<size_t>(asInteger(sizeParam));
     offset = static_cast<size_t>(asInteger(offsetParam));
     TPoolHandle pool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(poolParam));
@@ -428,7 +563,7 @@ EXPORT_FUNCTION CatBoostPoolSlice_R(SEXP poolParam, SEXP sizeParam, SEXP offsetP
         "Dataset slicing error: non-numeric features present, slicing datasets with categorical and text features is not supported"
     );
 
-    result = PROTECT(allocVector(VECSXP, size));
+    SEXP result = PROTECT(safe_R_vector(VECSXP, size, uw_token));
     ui32 featureCount = pool->MetaInfo.GetFeatureCount();
     auto target = pool->RawTargetData.GetTarget();
     const auto& weights = pool->RawTargetData.GetWeights();
@@ -458,10 +593,10 @@ EXPORT_FUNCTION CatBoostPoolSlice_R(SEXP poolParam, SEXP sizeParam, SEXP offsetP
 
     for (size_t i = offset; i < sliceEnd; ++i) {
         ui32 featureCount = pool->MetaInfo.GetFeatureCount();
-        SEXP row = PROTECT(allocVector(REALSXP, featureCount + targetCount + 1));
+        SEXP row = safe_R_vector(REALSXP, featureCount + targetCount + 1, uw_token);
+        SET_VECTOR_ELT(result, i - offset, row);
         REAL(row)[targetCount] = weights[i];
         rows.push_back(REAL(row));
-        SET_VECTOR_ELT(result, i - offset, row);
     }
 
     for (auto targetIdx : xrange(targetCount)) {
@@ -506,20 +641,21 @@ EXPORT_FUNCTION CatBoostPoolSlice_R(SEXP poolParam, SEXP sizeParam, SEXP offsetP
         }
     }
 
-    R_API_END();
-    UNPROTECT(size - offset + 1);
+    UNPROTECT(2);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostFit_R(SEXP learnPoolParam, SEXP testPoolParam, SEXP fitParamsAsJsonParam) {
-    SEXP result = NULL;
+    SEXP fitParamsAsJsonParam_char = PROTECT(Rf_asChar(fitParamsAsJsonParam));
+    SEXP result = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
     R_API_BEGIN();
     TPoolHandle learnPool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(learnPoolParam));
     TDataProviders pools;
     pools.Learn = learnPool;
     pools.Learn->Ref();
 
-    auto fitParams = LoadFitParams(fitParamsAsJsonParam);
+    auto fitParams = LoadFitParams(CHAR(fitParamsAsJsonParam_char));
     TFullModelPtr modelPtr = std::make_unique<TFullModel>();
     if (testPoolParam != R_NilValue) {
         TEvalResult evalResult;
@@ -555,23 +691,25 @@ EXPORT_FUNCTION CatBoostFit_R(SEXP learnPoolParam, SEXP testPoolParam, SEXP fitP
             {}
         );
     }
-    result = PROTECT(R_MakeExternalPtr(modelPtr.get(), R_NilValue, R_NilValue));
+    R_SetExternalPtrAddr(result, modelPtr.get());
     R_RegisterCFinalizerEx(result, _Finalizer<TFullModelHandle>, TRUE);
     modelPtr.release();
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(2);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostSumModels_R(SEXP modelsParam,
                          SEXP weightsParam,
                          SEXP ctrMergePolicyParam) {
-    SEXP result = NULL;
+    SEXP result =  PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+    SEXP weightsParam_char = PROTECT(Rf_asChar(weightsParam));
+    SEXP ctrMergePolicyParam_char = PROTECT(Rf_asChar(ctrMergePolicyParam));
     R_API_BEGIN();
     const auto& weights = GetVectorFromSEXP<double>(weightsParam);
     ECtrTableMergePolicy mergePolicy;
-    CB_ENSURE(TryFromString<ECtrTableMergePolicy>(CHAR(asChar(ctrMergePolicyParam)), mergePolicy),
-        "Unknown value of ctr_table_merge_policy: " << CHAR(asChar(ctrMergePolicyParam)));
+    CB_ENSURE(TryFromString<ECtrTableMergePolicy>(CHAR(weightsParam_char), mergePolicy),
+        "Unknown value of ctr_table_merge_policy: " << CHAR(ctrMergePolicyParam_char));
 
     TVector<TFullModelConstPtr> models;
     for (int idx = 0; idx < length(modelsParam); ++idx) {
@@ -580,12 +718,12 @@ EXPORT_FUNCTION CatBoostSumModels_R(SEXP modelsParam,
     }
     TFullModelPtr modelPtr = std::make_unique<TFullModel>();
     SumModels(models, weights, mergePolicy).Swap(*modelPtr);
-    result = PROTECT(R_MakeExternalPtr(modelPtr.get(), R_NilValue, R_NilValue));
+    R_SetExternalPtrAddr(result, modelPtr.get());
     R_RegisterCFinalizerEx(result, _Finalizer<TFullModelHandle>, TRUE);
     modelPtr.release();
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(3);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostCV_R(SEXP fitParamsAsJsonParam,
@@ -595,15 +733,17 @@ EXPORT_FUNCTION CatBoostCV_R(SEXP fitParamsAsJsonParam,
                   SEXP partitionRandomSeedParam,
                   SEXP shuffleParam,
                   SEXP stratifiedParam) {
-
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
+    size_t n_protected = 1;
+    R_API_BEGIN();
     size_t metricCount;
     size_t columnCount;
 
-    R_API_BEGIN();
     TPoolPtr pool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(poolParam));
     pool->Ref();
-    auto fitParams = LoadFitParams(fitParamsAsJsonParam);
+    SEXP fitParamsAsJsonParam_char = PROTECT(safe_R_asChar(fitParamsAsJsonParam, uw_token));
+    n_protected++;
+    auto fitParams = LoadFitParams(CHAR(fitParamsAsJsonParam_char));
 
     TCrossValidationParams cvParams;
     cvParams.FoldCount = asInteger(foldCountParam);
@@ -611,7 +751,9 @@ EXPORT_FUNCTION CatBoostCV_R(SEXP fitParamsAsJsonParam,
     cvParams.Shuffle = asLogical(shuffleParam);
     cvParams.Stratified = asLogical(stratifiedParam);
 
-    CB_ENSURE(TryFromString<ECrossValidation>(CHAR(asChar(typeParam)), cvParams.Type),
+    SEXP typeParam_char = PROTECT(safe_R_asChar(typeParam, uw_token));
+    n_protected++;
+    CB_ENSURE(TryFromString<ECrossValidation>(CHAR(typeParam_char), cvParams.Type),
               "unsupported type of cross_validation: 'Classical', 'Inverted', 'TimeSeries' was expected");
 
     TVector<TCVResult> cvResults;
@@ -640,21 +782,24 @@ EXPORT_FUNCTION CatBoostCV_R(SEXP fitParamsAsJsonParam,
         columnCount += currentColumnCount;
     }
 
-    result = PROTECT(allocVector(VECSXP, columnCount));
-    SEXP columnNames = PROTECT(allocVector(STRSXP, columnCount));
+    SEXP result = PROTECT(safe_R_vector(VECSXP, columnCount, uw_token));
+    SEXP columnNames = PROTECT(safe_R_vector(STRSXP, columnCount, uw_token));
+    n_protected += 2;
 
     for (size_t metricIdx = 0; metricIdx < metricCount; ++metricIdx) {
         TString metricName = cvResults[metricIdx].Metric;
         size_t numberOfIterations = cvResults[metricIdx].Iterations.size();
 
-        SEXP row_test_mean = PROTECT(allocVector(REALSXP, numberOfIterations));
-        SEXP row_test_std = PROTECT(allocVector(REALSXP, numberOfIterations));
+        SEXP row_test_mean = PROTECT(safe_R_vector(REALSXP, numberOfIterations, uw_token));
+        SEXP row_test_std = PROTECT(safe_R_vector(REALSXP, numberOfIterations, uw_token));
+        n_protected += 2;
         SEXP row_train_mean = NULL;
         SEXP row_train_std = NULL;
         const bool haveTrainResult = (cvResults[metricIdx].AverageTrain.size() != 0);
         if (haveTrainResult) {
-            row_train_mean = PROTECT(allocVector(REALSXP, numberOfIterations));
-            row_train_std = PROTECT(allocVector(REALSXP, numberOfIterations));
+            row_train_mean = PROTECT(safe_R_vector(REALSXP, numberOfIterations, uw_token));
+            row_train_std = PROTECT(safe_R_vector(REALSXP, numberOfIterations, uw_token));
+            n_protected += 2;
         }
 
         for (size_t i = 0; i < numberOfIterations; ++i) {
@@ -671,26 +816,32 @@ EXPORT_FUNCTION CatBoostCV_R(SEXP fitParamsAsJsonParam,
         SET_VECTOR_ELT(result, offset + 0, row_test_mean);
         SET_VECTOR_ELT(result, offset + 1, row_test_std);
 
-        SET_STRING_ELT(columnNames, offset + 0, mkChar(("test-" + metricName + "-mean").c_str()));
-        SET_STRING_ELT(columnNames, offset + 1, mkChar(("test-" + metricName + "-std").c_str()));
+        SET_STRING_ELT(columnNames, offset + 0,
+                       safe_R_mkChar(("test-" + metricName + "-mean").c_str(), uw_token));
+        SET_STRING_ELT(columnNames, offset + 1,
+                       safe_R_mkChar(("test-" + metricName + "-std").c_str(), uw_token));
         if (haveTrainResult) {
             SET_VECTOR_ELT(result, offset + 2, row_train_mean);
             SET_VECTOR_ELT(result, offset + 3, row_train_std);
 
-            SET_STRING_ELT(columnNames, offset + 2, mkChar(("train-" + metricName + "-mean").c_str()));
-            SET_STRING_ELT(columnNames, offset + 3, mkChar(("train-" + metricName + "-std").c_str()));
+            SET_STRING_ELT(columnNames, offset + 2,
+                           safe_R_mkChar(("train-" + metricName + "-mean").c_str(), uw_token));
+            SET_STRING_ELT(columnNames, offset + 3,
+                           safe_R_mkChar(("train-" + metricName + "-std").c_str(), uw_token));
         }
     }
 
     setAttrib(result, R_NamesSymbol, columnNames);
 
-    R_API_END();
-    UNPROTECT(columnCount + 2);
+    UNPROTECT(n_protected);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostOutputModel_R(SEXP modelParam, SEXP fileParam,
                            SEXP formatParam, SEXP exportParametersParam, SEXP poolParam) {
+    SEXP result = PROTECT(ScalarLogical(1));
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
     THashMap<ui32, TString> catFeaturesHashToString;
@@ -702,71 +853,78 @@ EXPORT_FUNCTION CatBoostOutputModel_R(SEXP modelParam, SEXP fileParam,
         featureId = pool->MetaInfo.FeaturesLayout.Get()->GetExternalFeatureIds();
     }
 
+    SEXP formatParam_char = PROTECT(safe_R_asChar(formatParam, uw_token));
+    SEXP fileParam_char = PROTECT(safe_R_asChar(fileParam, uw_token));
+    SEXP exportParametersParam_char = PROTECT(safe_R_asChar(exportParametersParam, uw_token));
     EModelType modelType;
-    CB_ENSURE(TryFromString<EModelType>(CHAR(asChar(formatParam)), modelType),
+    CB_ENSURE(TryFromString<EModelType>(CHAR(formatParam_char), modelType),
               "unsupported model type: 'cbm', 'coreml', 'cpp', 'python', 'json', 'onnx' or 'pmml' was expected");
 
     ExportModel(*model,
-                CHAR(asChar(fileParam)),
+                CHAR(fileParam_char),
                 modelType,
-                CHAR(asChar(exportParametersParam)),
+                CHAR(exportParametersParam_char),
                 false,
                 &featureId,
                 &catFeaturesHashToString
                 );
+    UNPROTECT(5);
+    return result;
     R_API_END();
-    return ScalarLogical(1);
 }
 
 EXPORT_FUNCTION CatBoostReadModel_R(SEXP fileParam, SEXP formatParam) {
-    SEXP result = NULL;
+    SEXP formatParam_char = PROTECT(Rf_asChar(formatParam));
+    SEXP fileParam_char = PROTECT(Rf_asChar(fileParam));
+    SEXP result = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
     R_API_BEGIN();
     EModelType modelType;
-    CB_ENSURE(TryFromString<EModelType>(CHAR(asChar(formatParam)), modelType),
+    CB_ENSURE(TryFromString<EModelType>(CHAR(formatParam_char), modelType),
               "unsupported model type: 'CatboostBinary', 'AppleCoreML','Cpp','Python','Json','Onnx' or 'Pmml'  was expected");
     TFullModelPtr modelPtr = std::make_unique<TFullModel>();
-    ReadModel(CHAR(asChar(fileParam)), modelType).Swap(*modelPtr);
-    result = PROTECT(R_MakeExternalPtr(modelPtr.get(), R_NilValue, R_NilValue));
+    ReadModel(CHAR(fileParam_char), modelType).Swap(*modelPtr);
+    R_SetExternalPtrAddr(result, modelPtr.get());
     R_RegisterCFinalizerEx(result, _Finalizer<TFullModelHandle>, TRUE);
     modelPtr.release();
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(3);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostSerializeModel_R(SEXP handleParam) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
     TFullModelHandle modelHandle = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(handleParam));
     const TString& raw = SerializeModel(*modelHandle);
-    result = PROTECT(allocVector(RAWSXP, raw.size()));
+    SEXP result = PROTECT(safe_R_vector(RAWSXP, raw.size(), uw_token));
     MemCopy(RAW(result), (const unsigned char*)(raw.data()), raw.size());
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(2);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostDeserializeModel_R(SEXP rawParam) {
-    SEXP result = NULL;
+    SEXP result = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
     R_API_BEGIN();
     TFullModelPtr modelPtr = std::make_unique<TFullModel>();
     DeserializeModel(TMemoryInput(RAW(rawParam), length(rawParam))).Swap(*modelPtr);
-    result = PROTECT(R_MakeExternalPtr(modelPtr.get(), R_NilValue, R_NilValue));
+    R_SetExternalPtrAddr(result, modelPtr.get());
     R_RegisterCFinalizerEx(result, _Finalizer<TFullModelHandle>, TRUE);
     modelPtr.release();
-    R_API_END();
     UNPROTECT(1);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostPredictMulti_R(SEXP modelParam, SEXP poolParam, SEXP verboseParam,
                             SEXP typeParam, SEXP treeCountStartParam, SEXP treeCountEndParam, SEXP threadCountParam) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
+    SEXP typeParam_char = PROTECT(safe_R_asChar(typeParam, uw_token));
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
     TPoolHandle pool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(poolParam));
     EPredictionType predictionType;
-    CB_ENSURE(TryFromString<EPredictionType>(CHAR(asChar(typeParam)), predictionType) &&
+    CB_ENSURE(TryFromString<EPredictionType>(CHAR(typeParam_char), predictionType) &&
               !IsUncertaintyPredictionType(predictionType) && predictionType != EPredictionType::InternalRawFormulaVal,
               "Unsupported prediction type: 'Probability', 'LogProbability', 'Class', 'RawFormulaVal', 'Exponent' or 'RMSEWithUncertainty' was expected");
     TVector<TVector<double>> prediction = ApplyModelMulti(*model,
@@ -777,20 +935,23 @@ EXPORT_FUNCTION CatBoostPredictMulti_R(SEXP modelParam, SEXP poolParam, SEXP ver
                                                           asInteger(treeCountEndParam),
                                                           UpdateThreadCount(asInteger(threadCountParam)));
     size_t predictionSize = prediction.size() * pool->ObjectsGrouping->GetObjectCount();
-    result = PROTECT(allocVector(REALSXP, predictionSize));
+    SEXP result = PROTECT(safe_R_vector(REALSXP, predictionSize, uw_token));
+    double *ptr_result = REAL(result);
     for (size_t i = 0, k = 0; i < pool->ObjectsGrouping->GetObjectCount(); ++i) {
         for (size_t j = 0; j < prediction.size(); ++j) {
-            REAL(result)[k++] = prediction[j][i];
+            ptr_result[k++] = prediction[j][i];
         }
     }
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(3);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostPrepareEval_R(SEXP approxParam, SEXP typeParam, SEXP lossFunctionName, SEXP columnCountParam, SEXP threadCountParam) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
+    SEXP typeParam_char = PROTECT(safe_R_asChar(typeParam, uw_token));
+    SEXP lossFunctionName_char = PROTECT(safe_R_asChar(lossFunctionName, uw_token));
     SEXP dataDim = getAttrib(approxParam, R_DimSymbol);
     size_t dataRows = static_cast<size_t>(INTEGER(dataDim)[0]) / asInteger(columnCountParam);
     TVector<TVector<double>> prediction(asInteger(columnCountParam), TVector<double>(dataRows));
@@ -804,31 +965,32 @@ EXPORT_FUNCTION CatBoostPrepareEval_R(SEXP approxParam, SEXP typeParam, SEXP los
     NPar::TLocalExecutor executor;
     executor.RunAdditionalThreads(UpdateThreadCount(asInteger(threadCountParam)) - 1);
     EPredictionType predictionType;
-    CB_ENSURE(TryFromString<EPredictionType>(CHAR(asChar(typeParam)), predictionType),
+    CB_ENSURE(TryFromString<EPredictionType>(CHAR(typeParam_char), predictionType),
               "unsupported prediction type: 'Probability', 'Class' or 'RawFormulaVal' was expected");
-    prediction = PrepareEval(predictionType, /* virtualEnsemblesCount*/ 1, CHAR(asChar(lossFunctionName)), prediction, &executor);
+    prediction = PrepareEval(predictionType, /* virtualEnsemblesCount*/ 1, CHAR(lossFunctionName_char), prediction, &executor);
 
     size_t predictionSize = prediction.size() * dataRows;
-    result = PROTECT(allocVector(REALSXP, predictionSize));
+    SEXP result = PROTECT(safe_R_vector(REALSXP, predictionSize, uw_token));
     double *ptr_result = REAL(result);
     for (size_t i = 0, k = 0; i < dataRows; ++i) {
         for (size_t j = 0; j < prediction.size(); ++j) {
             ptr_result[k++] = prediction[j][i];
         }
     }
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(4);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostPredictVirtualEnsembles_R(SEXP modelParam, SEXP poolParam, SEXP verboseParam,
                             SEXP typeParam, SEXP treeCountEndParam, SEXP virtualEnsemblesCountParam, SEXP threadCountParam) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
+    SEXP typeParam_char = PROTECT(safe_R_asChar(typeParam, uw_token));
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
     TPoolHandle pool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(poolParam));
     EPredictionType predictionType;
-    CB_ENSURE(TryFromString<EPredictionType>(CHAR(asChar(typeParam)), predictionType) && IsUncertaintyPredictionType(predictionType),
+    CB_ENSURE(TryFromString<EPredictionType>(CHAR(typeParam_char), predictionType) && IsUncertaintyPredictionType(predictionType),
               "Unsupported virtual ensembles prediction type: 'VirtEnsembles' or 'TotalUncertainty' was expected");
     TVector<TVector<double>> prediction = ApplyUncertaintyPredictions(*model,
                                                                       *pool,
@@ -838,65 +1000,74 @@ EXPORT_FUNCTION CatBoostPredictVirtualEnsembles_R(SEXP modelParam, SEXP poolPara
                                                                       asInteger(virtualEnsemblesCountParam),
                                                                       UpdateThreadCount(asInteger(threadCountParam)));
     size_t predictionSize = prediction.size() * pool->ObjectsGrouping->GetObjectCount();
-    result = PROTECT(allocVector(REALSXP, predictionSize));
+    SEXP result = PROTECT(safe_R_vector(REALSXP, predictionSize, uw_token));
+    double *ptr_result = REAL(result);
     for (size_t i = 0, k = 0; i < pool->ObjectsGrouping->GetObjectCount(); ++i) {
         for (size_t j = 0; j < prediction.size(); ++j) {
-            REAL(result)[k++] = prediction[j][i];
+            ptr_result[k++] = prediction[j][i];
         }
     }
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(3);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostShrinkModel_R(SEXP modelParam, SEXP treeCountStartParam, SEXP treeCountEndParam) {
+    SEXP result = PROTECT(ScalarLogical(1));
     R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
     model->Truncate(asInteger(treeCountStartParam), asInteger(treeCountEndParam));
+    UNPROTECT(1);
+    return result;
     R_API_END();
-    return ScalarLogical(1);
 }
 
 EXPORT_FUNCTION CatBoostDropUnusedFeaturesFromModel_R(SEXP modelParam) {
+    SEXP result = PROTECT(ScalarLogical(1));
     R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
     model->ModelTrees.GetMutable()->DropUnusedFeatures();
+    UNPROTECT(1);
+    return result;
     R_API_END();
-    return ScalarLogical(1);
 }
 
 EXPORT_FUNCTION CatBoostGetModelParams_R(SEXP modelParam) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
-    result = PROTECT(mkString(model->ModelInfo.at("params").c_str()));
-    R_API_END();
-    UNPROTECT(1);
+    auto temp = model->ModelInfo.at("params");
+    SEXP result = PROTECT(safe_R_mkString(temp.c_str(), uw_token));
+    UNPROTECT(2);
     return result;
+    R_API_END();
 }
 
 
 EXPORT_FUNCTION CatBoostGetPlainParams_R(SEXP modelParam) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
-    result = PROTECT(mkString(ToString(GetPlainJsonWithAllOptions(*model)).c_str()));
-    R_API_END();
-    UNPROTECT(1);
+    auto temp = ToString(GetPlainJsonWithAllOptions(*model)).c_str();
+    SEXP result = PROTECT(safe_R_mkString(temp, uw_token));
+    UNPROTECT(2);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostCalcRegularFeatureEffect_R(SEXP modelParam, SEXP poolParam, SEXP fstrTypeParam, SEXP threadCountParam) {
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
+    R_API_BEGIN();
     SEXP result = NULL;
     SEXP resultDim = NULL;
-    R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
     TDataProviderPtr pool = Rf_isNull(poolParam) ? nullptr :
                             reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(poolParam));
     if (pool) {
         pool->Ref();
     }
-    EFstrType fstrType = FromString<EFstrType>(CHAR(asChar(fstrTypeParam)));
+    SEXP fstrTypeParam_char = PROTECT(safe_R_asChar(fstrTypeParam, uw_token));
+    EFstrType fstrType = FromString<EFstrType>(CHAR(fstrTypeParam_char));
     const int threadCount = UpdateThreadCount(asInteger(threadCountParam));
     const bool multiClass = model->GetDimensionsCount() > 1;
     const bool verbose = false;
@@ -913,7 +1084,7 @@ EXPORT_FUNCTION CatBoostCalcRegularFeatureEffect_R(SEXP modelParam, SEXP poolPar
         size_t numClasses = numDocs > 0 ? fstr[0].size() : 0;
         size_t numValues = numClasses > 0 ? fstr[0][0].size() : 0;
         size_t resultSize = numDocs * numClasses * numValues;
-        result = PROTECT(allocVector(REALSXP, resultSize));
+        result = PROTECT(safe_R_vector(REALSXP, resultSize, uw_token));
         double *ptr_result = REAL(result);
         size_t r = 0;
         for (size_t k = 0; k < numValues; ++k) {
@@ -923,7 +1094,7 @@ EXPORT_FUNCTION CatBoostCalcRegularFeatureEffect_R(SEXP modelParam, SEXP poolPar
                 }
             }
         }
-        PROTECT(resultDim = allocVector(INTSXP, 3));
+        resultDim = PROTECT(safe_R_vector(INTSXP, 3, uw_token));
         INTEGER(resultDim)[0] = numDocs;
         INTEGER(resultDim)[1] = numClasses;
         INTEGER(resultDim)[2] = numValues;
@@ -939,7 +1110,7 @@ EXPORT_FUNCTION CatBoostCalcRegularFeatureEffect_R(SEXP modelParam, SEXP poolPar
         size_t numRows = fstr.size();
         size_t numCols = numRows > 0 ? fstr[0].size() : 0;
         size_t resultSize = numRows * numCols;
-        result = PROTECT(allocVector(REALSXP, resultSize));
+        result = PROTECT(safe_R_vector(REALSXP, resultSize, uw_token));
         double *ptr_result = REAL(result);
         size_t r = 0;
         for (size_t j = 0; j < numCols; ++j) {
@@ -947,14 +1118,14 @@ EXPORT_FUNCTION CatBoostCalcRegularFeatureEffect_R(SEXP modelParam, SEXP poolPar
                 ptr_result[r++] = fstr[i][j];
             }
         }
-        PROTECT(resultDim = allocVector(INTSXP, 2));
+        resultDim = PROTECT(safe_R_vector(INTSXP, 2, uw_token));
         INTEGER(resultDim)[0] = numRows;
         INTEGER(resultDim)[1] = numCols;
         setAttrib(result, R_DimSymbol, resultDim);
     }
-    R_API_END();
-    UNPROTECT(2);
+    UNPROTECT(4);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostEvaluateObjectImportances_R(
@@ -966,13 +1137,15 @@ EXPORT_FUNCTION CatBoostEvaluateObjectImportances_R(
     SEXP updateMethodParam,
     SEXP threadCountParam
 ) {
-    SEXP result = NULL;
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
     R_API_BEGIN();
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
     TPoolHandle pool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(poolParam));
     TPoolHandle trainPool = reinterpret_cast<TPoolHandle>(R_ExternalPtrAddr(trainPoolParam));
-    TString ostrType = CHAR(asChar(ostrTypeParam));
-    TString updateMethod = CHAR(asChar(updateMethodParam));
+    SEXP ostrTypeParam_char = PROTECT(safe_R_asChar(ostrTypeParam, uw_token));
+    SEXP updateMethodParam_char = PROTECT(safe_R_asChar(updateMethodParam, uw_token));
+    TString ostrType = CHAR(ostrTypeParam_char);
+    TString updateMethod = CHAR(updateMethodParam_char);
     const bool verbose = false;
     TDStrResult dstrResult = GetDocumentImportances(
         *model,
@@ -992,7 +1165,7 @@ EXPORT_FUNCTION CatBoostEvaluateObjectImportances_R(
     if (!dstrResult.Scores.empty()) {
         resultSize += dstrResult.Scores.size() * dstrResult.Scores[0].size();
     }
-    result = PROTECT(allocVector(REALSXP, resultSize));
+    SEXP result = PROTECT(safe_R_vector(REALSXP, resultSize, uw_token));
     double *ptr_result = REAL(result);
     size_t k = 0;
     for (size_t i = 0; i < dstrResult.Indices.size(); ++i) {
@@ -1005,9 +1178,9 @@ EXPORT_FUNCTION CatBoostEvaluateObjectImportances_R(
             ptr_result[k++] = dstrResult.Scores[i][j];
         }
     }
-    R_API_END();
-    UNPROTECT(1);
+    UNPROTECT(4);
     return result;
+    R_API_END();
 }
 
 EXPORT_FUNCTION CatBoostIsNullHandle_R(SEXP handleParam) {
@@ -1024,35 +1197,32 @@ EXPORT_FUNCTION CatBoostEvalMetrics_R(
         SEXP threadCountParam,
         SEXP tmpDirParam,
         SEXP resultDirParam) {
-
-    SEXP result = NULL;
-    size_t protectedCount = 0;
-
+    SEXP uw_token = PROTECT(R_MakeUnwindCont());
+    size_t n_protected = 1;
     R_API_BEGIN()
+
     auto treeCountStart = asInteger(treeCountStartParam);
     auto treeCountEnd = asInteger(treeCountEndParam);
     auto evalPeriod = asInteger(evalPeriodParam);
+
     CB_ENSURE(treeCountStart >= 0, "Tree start index should be greater or equal zero");
     CB_ENSURE(treeCountStart < treeCountEnd, "Tree start index should be less than tree end index");
     CB_ENSURE(evalPeriod <= (treeCountEnd - treeCountStart), "Eval period should be less or equal than number of trees");
     CB_ENSURE(evalPeriod > 0, "Eval period should be more than zero");
 
-    size_t metricsParamLen = length(metricsParam);
+    size_t metricsParamLen = Rf_xlength(metricsParam);
     size_t treeCount = treeCountEnd - treeCountStart;
     size_t numberOfIterations = treeCount / evalPeriod;
     if (treeCountStart + (numberOfIterations - 1) * evalPeriod != static_cast<size_t>(treeCountEnd) - 1) {
         ++numberOfIterations;
     }
 
-    result = PROTECT(allocVector(VECSXP, metricsParamLen));
-    ++protectedCount;
-    SEXP metricNames = PROTECT(allocVector(STRSXP, metricsParamLen));
-    ++protectedCount;
+    SEXP result = PROTECT(safe_R_vector(VECSXP, metricsParamLen, uw_token));
+    SEXP metricNames = PROTECT(safe_R_vector(STRSXP, metricsParamLen, uw_token));
+    n_protected += 2;
 
     for (size_t metricIdx = 0; metricIdx < metricsParamLen; ++metricIdx) {
-        SEXP metricScore = PROTECT(allocVector(REALSXP, numberOfIterations));
-        ++protectedCount;
-        SET_VECTOR_ELT(result, metricIdx, metricScore);
+        SET_VECTOR_ELT(result, metricIdx, safe_R_vector(REALSXP, numberOfIterations, uw_token));
     }
 
     TFullModelHandle model = reinterpret_cast<TFullModelHandle>(R_ExternalPtrAddr(modelParam));
@@ -1063,11 +1233,15 @@ EXPORT_FUNCTION CatBoostEvalMetrics_R(
     metricDescriptions.reserve(metricsParamLen);
     metricLossDescriptions.reserve(metricsParamLen);
     for (size_t i = 0; i < metricsParamLen; ++i) {
-        TString metricDescription = CHAR(asChar(VECTOR_ELT(metricsParam, i)));
+        SEXP temp = PROTECT(safe_R_asChar(VECTOR_ELT(metricsParam, i), uw_token));
+        n_protected++;
+        TString metricDescription = CHAR(temp);
         metricDescriptions.push_back(metricDescription);
         metricLossDescriptions.emplace_back(NCatboostOptions::ParseLossDescription(metricDescription));
     }
     auto metrics = CreateMetrics(metricLossDescriptions, model->GetDimensionsCount());
+    SEXP tmpDirParam_char = PROTECT(safe_R_asChar(tmpDirParam, uw_token));
+    n_protected++;
 
     NPar::TLocalExecutor executor;
     executor.RunAdditionalThreads(UpdateThreadCount(asInteger(threadCountParam)) - 1);
@@ -1078,7 +1252,7 @@ EXPORT_FUNCTION CatBoostEvalMetrics_R(
         treeCountEnd,
         evalPeriod,
         /*processedIterationsStep=*/50,
-        CHAR(asChar(tmpDirParam)),
+        CHAR(tmpDirParam_char),
         metrics,
         &executor
     );
@@ -1104,22 +1278,25 @@ EXPORT_FUNCTION CatBoostEvalMetrics_R(
     }
 
     TVector<TVector<double>> metricsScore = plotCalcer.GetMetricsScore();
-    plotCalcer.SaveResult(CHAR(asChar(resultDirParam)), /*metricsFile=*/"", /*saveMetrics*/ false, /*saveStats=*/true).ClearTempFiles();
+    SEXP resultDirParam_char = PROTECT(safe_R_asChar(resultDirParam, uw_token));
+    n_protected++;
+    plotCalcer.SaveResult(CHAR(resultDirParam_char), /*metricsFile=*/"", /*saveMetrics*/ false, /*saveStats=*/true).ClearTempFiles();
 
     auto metricsResult = CreateMetricsFromDescription(metricDescriptions, model->GetDimensionsCount());
     for (size_t metricIdx = 0; metricIdx < metricsParamLen; ++metricIdx) {
         TString metricName = metricsResult[metricIdx]->GetDescription();
         SEXP metricScoreResult = VECTOR_ELT(result, metricIdx);
+        double *ptr_metricScoreResult = REAL(metricScoreResult);
         for (size_t i = 0; i < numberOfIterations; ++i) {
-            REAL(metricScoreResult)[i] = metricsScore[metricIdx][i];
+            ptr_metricScoreResult[i] = metricsScore[metricIdx][i];
         }
-        SET_STRING_ELT(metricNames, metricIdx, mkChar(metricName.c_str()));
+        SET_STRING_ELT(metricNames, metricIdx, safe_R_mkChar(metricName.c_str(), uw_token));
     }
 
     setAttrib(result, R_NamesSymbol, metricNames);
 
-    R_API_END();
-    UNPROTECT(protectedCount);
+    UNPROTECT(n_protected);
     return result;
+    R_API_END();
 }
 }


### PR DESCRIPTION
This PR fixes a couple of potential memory leaks and use-after-free errors in the R version. In short, lots of these errors come from 2 patterns:
* Throwing R errors in a catch block, which trigger C long jumps and end up leaking the exception object.
* Not protecting R objects of dynamic storage, which might get deallocated at the moment they are to be used.

Some information about the new functions used here (particularly unwind protection) can be found in the R extensions manual: https://cran.r-project.org/doc/manuals/R-exts.html

**IMPORTANT:** Getting this PR to compile requires updating the R headers to something more recent, such as version 4.0.0 (see https://github.com/catboost/catboost/issues/1851). Current headers under `contrib` are at 3.5.0 and lack some of the functions used in this PR.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
