### PR TITLE
fix: Add a missing comma in the `supported_by` set

### DIFF
--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -6155,7 +6155,7 @@ class Metrics(object):
             'Poisson',
             'Quantile',
             'RMSE',
-            'RMSEWithUncertainty'
+            'RMSEWithUncertainty',
             'LogLinQuantile',
             'SMAPE',
             'R2',


### PR DESCRIPTION
* This comma is most probably missing unintentionally, leading to string concatenation. It was found using a regular expression.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.