### PR TITLE
fix: typo to_classifier to to_regressor

### DIFF
--- a/catboost/docs/en/concepts/python-reference_to_regressor.md
+++ b/catboost/docs/en/concepts/python-reference_to_regressor.md
@@ -22,7 +22,7 @@ to_regressor(model)
 ## {{ input_data__title__example }} {#example}
 
 ```python
-from catboost import Pool, to_classifier, CatBoost
+from catboost import Pool, to_regressor, CatBoost
 
 train_data = [[0, 3],
               [4, 1],
@@ -38,7 +38,7 @@ model.fit(train_data,
           verbose=False)
 
 print("Source model type: ", type(model))
-converted_model = to_classifier(model)
+converted_model = to_regressor(model)
 print("Converted model type: ",  type(converted_model))
 
 ```


### PR DESCRIPTION
the documentation example points to_classifier however it seems the document itself is about to_regressor method.

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Run `ya make` in catboost folder to make sure the code builds.
3. Add tests that test your change.
4. Run tests using `ya make -t -A` command.
5. If you haven't already, complete the [CLA](https://yandex.ru/legal/cla/).
