### PR TITLE
rust: better error ergonomics

### DIFF
--- a/catboost/rust-package/src/error.rs
+++ b/catboost/rust-package/src/error.rs
@@ -1,5 +1,6 @@
 use catboost_sys;
 use std::ffi::CStr;
+use std::fmt;
 
 pub type CatBoostResult<T> = std::result::Result<T, CatBoostError>;
 
@@ -28,3 +29,11 @@ impl CatBoostError {
         }
     }
 }
+
+impl fmt::Display for CatBoostError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.description)
+    }
+}
+
+impl std::error::Error for CatBoostError {}


### PR DESCRIPTION
This implements the std::error::Error type for CatBoostError in the rust package. Doing so marks CatBoostError as an error type and  allows the library to better integrate with the Rust's ecosystem for error handling.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en