### PR TITLE
docs typo: get_object_importance parameters, change int to str for parameter "type"

### DIFF
--- a/catboost/docs/en/_includes/work_src/reusage/get_object_importance__parameters.md
+++ b/catboost/docs/en/_includes/work_src/reusage/get_object_importance__parameters.md
@@ -56,7 +56,7 @@ Possible values:
 
 **Possible types**
 
-{{ python-type--int }}
+{{ python-type--string }}
 
 **Default value**
 


### PR DESCRIPTION
docs typo: get_object_importance parameters, change int to str for parameter "type"

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en