### PR TITLE
Package the ipywidget AMD module for CDN distribution

### DIFF
--- a/catboost/python-package/catboost/widget/js/package.json
+++ b/catboost/python-package/catboost/widget/js/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "CatBoost widget for plots in Jupyter",
   "main": "src/index.js",
+  "files": [
+    "src/**/*",
+    "dist/**/*"
+  ],
   "scripts": {
     "build": "webpack --mode=production && jupyter labextension build .",
     "clean": "rimraf dist && rimraf ../nbextension && rimraf ../labextension",


### PR DESCRIPTION
In #1673, effort was made to distribute the catboost javascript via CDN. However, the AMD module built in the dist/ directory from the webpack config (for use in the ipywidgets html manager, voila, etc.) is not being distributed with the npm package. You can see that the dist/ directory is not available at https://www.jsdelivr.com/package/npm/catboost-widget - that is what is needed (by convention) to load the widget as an AMD module in the ipywidgets html manager or Voila html manager.

This should fix the issue by adding the dist/ directory to the things npm will package up.

Fixes #2134
