### PR TITLE
Support M1 for Rust

### DIFF
--- a/catboost/rust-package/Cargo.toml
+++ b/catboost/rust-package/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Sergey Kiselev <kiselev.sg@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-catboost-sys = { path = "catboost-sys", version = "0.1"}
+catboost-sys = { path = "catboost-sys", version = "0.1.1"}
 # catboost-sys = "0.1"

--- a/catboost/rust-package/catboost-sys/Cargo.lock
+++ b/catboost/rust-package/catboost-sys/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 
 [[package]]
 name = "catboost-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bindgen",
 ]

--- a/catboost/rust-package/catboost-sys/Cargo.toml
+++ b/catboost/rust-package/catboost-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catboost-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sergey Kiselev <kiselev.sg@gmail.com>"]
 edition = "2018"
 

--- a/catboost/rust-package/catboost-sys/build.rs
+++ b/catboost/rust-package/catboost-sys/build.rs
@@ -11,15 +11,21 @@ fn main() {
         .canonicalize()
         .unwrap();
 
+    let mut ya_args = vec![
+        "make",
+        "-r",
+        cb_model_interface_root.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ];
+
+    if target.contains("apple") && target.contains("aarch64") {
+        let mut target_platform_args = vec!["--target-platform", "CLANG12-DARWIN-ARM64"];
+        ya_args.append(&mut target_platform_args);
+    }
+
     Command::new("../../../ya")
-        .args(&[
-            "make",
-            "-r",
-            cb_model_interface_root.to_str().unwrap(),
-            // "--sanitize=address",
-            "-o",
-            out_dir.to_str().unwrap(),
-        ])
+        .args(ya_args)
         .status()
         .unwrap_or_else(|e| {
             panic!("Failed to yamake libcatboostmodel: {}", e);


### PR DESCRIPTION
If apple arm detected, specificy --target-platform to be CLANG12-DARWIN-ARM64 so that the right libcatboost is built

Tested locally on my M1 Macbook pointing to my own branch in Cargo.toml: 
`catboost = { git = "https://github.com/jlloh/catboost", branch = "rust-apple-m1-support" }`.


I hereby agree to the terms of the CLA available at: [https://yandex.ru/legal/cla/?lang=en](https://yandex.ru/legal/cla/?lang=en).
