### PR TITLE
Update python-usages_examples.md

### DIFF
--- a/catboost/docs/en/concepts/python-usages-examples.md
+++ b/catboost/docs/en/concepts/python-usages-examples.md
@@ -905,7 +905,7 @@ model1.fit(X=batch1)
 
 model2 = CatBoostRegressor(**params)
 batch2 = Pool(train_data2, label=train_labels2)
-batch2.set_baseline(model1.predict(batch1))
+batch2.set_baseline(model1.predict(batch2))
 model2.fit(X=batch2)
 
 # build resulting model


### PR DESCRIPTION
Hello,

It seemed to me that the batch training example had a typo. The baseline for the second batch should be the predictions of the first model for the second batch instead of the first batch. Let me know if this is not true.
Thanks.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.