### PR TITLE
Add GetModelUsedFeaturesNames to exports

### DIFF
--- a/catboost/libs/model_interface/calcer.exports
+++ b/catboost/libs/model_interface/calcer.exports
@@ -46,3 +46,4 @@ C GetPredictionDimensionsCount
 C CheckModelMetadataHasKey
 C GetModelInfoValueSize
 C GetModelInfoValue
+C GetModelUsedFeaturesNames


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.

small fix to https://github.com/catboost/catboost/commit/aae748f2be56e42a0dadd1d3cde355b4e915e0be
add GetFeatures to calcer.exports
