### PR TITLE
Fix BuildDescription() double commas

### DIFF
--- a/catboost/libs/metrics/description_utils.h
+++ b/catboost/libs/metrics/description_utils.h
@@ -39,7 +39,11 @@ inline TString BuildDescription(const char* fmt, const TMetricParam<TVector<doub
         TStringBuilder description;
         description << param.GetName() << "=" << Sprintf(fmt, param.Get()[0]) << ",";
         for (auto idx : xrange<size_t>(1, param.Get().size(), 1)) {
-            description << "," << Sprintf(fmt, param.Get()[idx]);
+            if (idx < param.Get().size() - 1) {
+                description << Sprintf(fmt, param.Get()[idx]) << ",";
+            } else {
+                description << Sprintf(fmt, param.Get()[idx]);
+            }
         }
         return description;
     }


### PR DESCRIPTION
In the `BuildDescription()` the for loop was not properly checking for the last element before adding a comma. As a result, the function was adding an extra comma for some inputs. For instance, if the loss is set to "MultiQuantile:alpha=0.1,0.5,0.9", it would be rendered as "MultiQuantile:alpha=0.1,,0.5,0.9". In practice, this is an issue because the loss function is sometimes used as a key in dicts. If the formatting is off this can give rise to bugs.

This commit fixes the issue by reordering the value and comma placement in the loop. For the last element, it refrains from putting a comma.

Examples:
- Input: "MultiQuantile:alpha=0.1,0.5,0.9"
- Output before fix: "MultiQuantile:alpha=0.1,,0.5,0.9"
- Output after fix: "MultiQuantile:alpha=0.1,0.5,0.9"

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en