### PR TITLE
fix: model_interface/cmake_example failed build "‘runtime_error’ is not a member of ‘std’"

### DIFF
--- a/catboost/libs/model_interface/wrapped_calcer.h
+++ b/catboost/libs/model_interface/wrapped_calcer.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 
 /**
  * Model C API header-only wrapper class


### PR DESCRIPTION
## Steps to reproduce the issue

0. Go to the catboost project root folder
1. Check out to the latest master, for me, it's:

```
git checkout ebbec10488bca641d66dbc83c585f43384d2a1a5
```

2. Navigate to model_interface/cmake_example

```
cd catboost/libs/model_interface/cmake_example 
```

3. Execute `cmake -B build -S .`

```
~/.../catboost/catboost/libs/model_interface/cmake_example# cmake -B build -S .

CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- The C compiler identification is Clang 15.0.6
-- The CXX compiler identification is Clang 15.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /.../catboost/catboost/libs/model_interface/cmake_example/build
```

4. Execute `cmake --build build`

```
~/.../catboost/catboost/libs/model_interface/cmake_example# cmake --build build

[ 50%] Building CXX object CMakeFiles/catboost_demo.dir/main.cpp.o
In file included from /.../catboost/catboost/libs/model_interface/cmake_example/main.cpp:1:
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:34:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:47:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:57:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:71:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:87:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:132:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:177:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:199:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:262:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:321:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:380:24: error: no member named 'runtime_error' in namespace 'std'
            throw std::runtime_error(GetErrorString());
                  ~~~~~^
/.../catboost/catboost/libs/model_interface/cmake_example/../wrapped_calcer.h:431:28: error: no member named 'runtime_error' in namespace 'std'
                throw std::runtime_error("All text feature vectors should be of the same length");
                      ~~~~~^
12 errors generated.
gmake[2]: *** [CMakeFiles/catboost_demo.dir/build.make:76: CMakeFiles/catboost_demo.dir/main.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/catboost_demo.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```
 
After applying the fix, the errors on step 4 changed to:

```
~/.../catboost/catboost/libs/model_interface/cmake_example# cmake --build build
Consolidate compiler generated dependencies of target catboost_demo
[ 50%] Building CXX object CMakeFiles/catboost_demo.dir/main.cpp.o
gmake[2]: *** No rule to make target 'libcatboostmodel.so', needed by 'catboost_demo'.  Stop.
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/catboost_demo.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```

Which is another error, but can be resolved by providing the app runtime dependencies.

**Please note:**
- In the latest master the `ya` tools are deleted, so I can't run the `ya make` and `ya make -t -A` build process. So will need help on this.
- The test are provided in the above PR description. When the fix is applied, the error no longer appears.
- I'm still learning C++, CMake, and C++ toolings, so please let me know if the steps to reproduce the issue is not found, thank you

I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=en).

