### PR TITLE
TFocalMetric negative values fix

### DIFF
--- a/catboost/libs/metrics/metric.cpp
+++ b/catboost/libs/metrics/metric.cpp
@@ -1687,25 +1687,13 @@ TMetricHolder TFocalMetric::EvalSingleThread(
             const float w = hasWeight ? weight[k] : 1;
             double FocalAlpha = 0.75;
             double FocalGamma = 2;
-            double at, p, pt, y, margin;
-            double u, du, v, dv, der2;
+            double at, p, pt, margin;
 
             curApprox = 1 / (1 + exp(-curApprox));
             at = target[k] == 1 ? FocalAlpha : 1 - FocalAlpha;
             p = std::clamp(curApprox, 0.0000000000001, 0.9999999999999);
             pt = target[k] == 1 ? p : 1 - p;
-            y = 2 * target[k] - 1;
-            margin = at * y * pow((1 - pt), FocalGamma);
-            margin = margin * (FocalGamma * pt * log(pt) + pt - 1);
-
-            // second derivative
-            u = at * y * pow((1 - pt), FocalGamma);
-            du = -at * y * pow(FocalGamma * (1 - pt), FocalGamma - 1);
-            v = FocalGamma * pt * log(pt) + pt - 1;
-            dv = FocalGamma * log(pt) + FocalGamma + 1;
-            der2 = (du * v + u * dv) * y * (pt * (1 - pt));
-
-            margin = margin + der2;
+            margin =  -at * pow((1 - pt), FocalGamma) * log(pt);
             error.Stats[0] += w * margin;
             error.Stats[1] += w;
             }


### PR DESCRIPTION
Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Run `ya make` in catboost folder to make sure the code builds.
3. Add tests that test your change.
4. Run tests using `ya make -t -A` command.
5. If you haven't already, complete the [CLA](https://yandex.ru/legal/cla/).

1 - +
2 - cmake via `python setup.py bdist_wheel --no-widget` builds it successfully.
3 - tests were not written by me, this is a fix for what's covered already - focal loss that I also wrote
4 - +
5 - I Did it already on the initial focal loss commit, but anyways I agree to it here.

The actual case was that metric in some cases becomes negative, which is not possible for focal loss itself by design.
The mistake is that I copied `loss` code part to `metric` code part - which means it calculated as the metric the sum of the first and second derivatives of the loss, not the loss itself.

Surely sum of derivatives could be negative, and while this does not affect the actual model(the loss is correct), it confused users by showing although diminishing,  loss value going negative.
