### PR TITLE
Adding KGB support

### DIFF
--- a/catboost/python-package/catboost/__init__.py
+++ b/catboost/python-package/catboost/__init__.py
@@ -1,6 +1,6 @@
 from .core import (
     FeaturesData, EFstrType, EShapCalcType, EFeaturesSelectionAlgorithm, EFeaturesSelectionGrouping,
-    Pool, CatBoost, CatBoostClassifier, CatBoostRegressor, CatBoostRanker, CatBoostError, cv, train,
+    Pool, CatBoost, CatBoostClassifier, CatBoostRegressor, CatBoostRanker, CatBoostError, cv, sample_gaussian_process, train,
     sum_models, _have_equal_features, to_regressor, to_classifier, to_ranker, MultiRegressionCustomMetric,
     MultiRegressionCustomObjective, MultiTargetCustomMetric, MultiTargetCustomObjective
 )  # noqa
@@ -8,7 +8,7 @@ from .version import VERSION as __version__  # noqa
 __all__ = [
     'FeaturesData', 'EFstrType', 'EShapCalcType', 'EFeaturesSelectionAlgorithm', 'EFeaturesSelectionGrouping',
     'Pool', 'CatBoost', 'CatBoostClassifier', 'CatBoostRegressor', 'CatBoostRanker', 'CatboostError',
-    'cv', 'train', 'sum_models', '_have_equal_features',
+    'cv', 'sample_gaussian_process', 'train', 'sum_models', '_have_equal_features',
     'to_regressor', 'to_classifier', 'to_ranker', 'MultiRegressionCustomMetric', 'MultiRegressionCustomObjective',
     'MultiTargetCustomMetric', 'MultiTargetCustomObjective'
 ]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/.

Based on https://arxiv.org/abs/2206.05608

I've a bit forgot codebase for C++ part and some changes are needed to fully satisfy what is implemented in the paper, though they are not essential parts of the approach and fairly it can be added without them without violating theory in the paper.
Nevertheless, here is list of changes that are needed to added:
1. add option that modified random_strength behavior by removing dependence of model_length and Gumbel noise (log(log(1/uniform))), instead of normal noise
2. current prior sampling is done by somewhat tricky procedure (though correct one) that ensures through parameter eps that prior trees are uniformly distributed and then by manually overriding leaf values to make them distributed as gaussians. I think that this step can be incorporated directly into train-one-iteration but amount of changes needed to do that probably not worth it.


