### PR TITLE
fix name of parameter in snapshots.md

### DIFF
--- a/catboost/docs/en/features/snapshots.md
+++ b/catboost/docs/en/features/snapshots.md
@@ -52,9 +52,9 @@ The native {{ product }} model file ({{ yandex-specific__model_ops__EConvertMode
 
   {% endcut %}
 
-  {% cut "save_snapshot" %}
+  {% cut "snapshot_file" %}
 
-   `save_snapshot`
+   `snapshot_file`
 
    The name of the file to save the training progress information in. This file is used for [recovering training after an interruption](../features/snapshots.md).
 


### PR DESCRIPTION
The name of the parameter for the snapshot file was wrong and has been corrected from save_snapshot to snapshot_file.
