### PR TITLE
Improved error message for CPP exporter

### DIFF
--- a/catboost/libs/model/model_export/cpp_exporter.h
+++ b/catboost/libs/model/model_export/cpp_exporter.h
@@ -22,8 +22,8 @@ namespace NCB {
         void Write(const TFullModel& model, const THashMap<ui32, TString>* catFeaturesHashToString = nullptr) override {
             if (model.HasCategoricalFeatures()) {
                 CB_ENSURE(catFeaturesHashToString != nullptr,
-                          "need train pool to save mapping {categorical feature value, hash value} "
-                          "due to absence of hash function in model");
+                          "Need to use training dataset Pool to save mapping {categorical feature value -> hash value} "
+                          "due to the absence of a hash function in the model");
                 WriteHeader(/*forCatFeatures*/true);
                 WriteModelCatFeatures(model, catFeaturesHashToString);
                 WriteApplicatorCatFeatures();

--- a/catboost/libs/model/model_export/python_exporter.h
+++ b/catboost/libs/model/model_export/python_exporter.h
@@ -22,8 +22,8 @@ namespace NCB {
         void Write(const TFullModel& model, const THashMap<ui32, TString>* catFeaturesHashToString) override {
             if (model.HasCategoricalFeatures()) {
                 CB_ENSURE(catFeaturesHashToString != nullptr,
-                          "need train pool to save mapping {categorical feature value, hash value} "
-                          "due to absence of hash function in model");
+                          "Need to use training dataset Pool to save mapping {categorical feature value -> hash value} "
+                          "due to the absence of a hash function in the model");
             }
             WriteModelCatFeatures(model, catFeaturesHashToString);
             WriteApplicatorCatFeatures();


### PR DESCRIPTION
## Improve error message when exporting a model that's not using a training data Pool

See https://github.com/catboost/catboost/pull/2283#discussion_r1208681517

## Licence

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
