### PR TITLE
Fix Bayesian bootstrap parameter name in docs

### DIFF
--- a/catboost/docs/en/concepts/algorithm-main-stages_bootstrap-options.md
+++ b/catboost/docs/en/concepts/algorithm-main-stages_bootstrap-options.md
@@ -31,7 +31,7 @@ Depending on the value of the `bootstrap_type` parameter, these ideas are implem
 The weight of an example is set to the following value:
 
 $w=a^{t} {, where:}$
-- $t$ is defined by the `bootstrap_type` parameter
+- $t$ is defined by the `bagging_temperature` parameter
 - $a=-log(\psi)$, where $\psi$ is independently generated from Uniform[0,1] . This is equivalent to generating values $a$ for all the examples according to the Bayesian bootstrap procedure (see D. Rubin “The Bayesian Bootstrap”, 1981, Section 2).
 
 {% note info %}


### PR DESCRIPTION
At the [Bootstrap options page](https://catboost.ai/en/docs/concepts/algorithm-main-stages_bootstrap-options#bayesian), the parameter for the Bayesian bootstrap that defines `t` should be `bagging_temperature` instead of `bootstrap_type`.

--
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en