### PR TITLE
Docs: Add a missing colon to the custom_metrics example.

### DIFF
--- a/catboost/docs/en/features/loss-functions-desc.md
+++ b/catboost/docs/en/features/loss-functions-desc.md
@@ -76,7 +76,7 @@ Examples:
 
 - Calculate the value of {{ error-function--Quantile }} with the coefficient $\alpha = 0.1$
     ```
-    {{ error-function--Quantile }}alpha=0.1
+    {{ error-function--Quantile }}:alpha=0.1
     ```
 
 


### PR DESCRIPTION
This simply adds a `:` to the example: `Quantile:alpha=0.1`