### PR TITLE
Fix the docs for "FailIfCtrIntersects" (#2497)

### DIFF
--- a/catboost/docs/en/_includes/work_src/reusage-python/python__sum-limits__parameters.md
+++ b/catboost/docs/en/_includes/work_src/reusage-python/python__sum-limits__parameters.md
@@ -36,7 +36,7 @@ None (leaf values weights are set to 1 for all models)
 #### Description
 
 The counters merging policy. Possible values:
-- {{ ECtrTableMergePolicy__FailIfCtrsIntersects }} — Ensure that the models have zero intersecting counters.
+- {{ ECtrTableMergePolicy__FailIfCtrIntersects }} — Ensure that the models have zero intersecting counters.
 - {{ ECtrTableMergePolicy__LeaveMostDiversifiedTable }} — Use the most diversified counters by the count of unique hash values.
 - {{ ECtrTableMergePolicy__IntersectingCountersAverage }} — Use the average ctr counter values in the intersecting bins.
 - {{ ECtrTableMergePolicy__KeepAllTables }} — Keep Counter and FeatureFreq ctr's from all models.

--- a/catboost/docs/en/concepts/cli-sum-models.md
+++ b/catboost/docs/en/concepts/cli-sum-models.md
@@ -53,7 +53,7 @@ The path to the output model obtained as the result of blending the input ones.
 #### Description
 
 The counters merging policy. Possible values:
-- {{ ECtrTableMergePolicy__FailIfCtrsIntersects }} — Ensure that the models have zero intersecting counters.
+- {{ ECtrTableMergePolicy__FailIfCtrIntersects }} — Ensure that the models have zero intersecting counters.
 - {{ ECtrTableMergePolicy__LeaveMostDiversifiedTable }} — Use the most diversified counters by the count of unique hash values.
 - {{ ECtrTableMergePolicy__IntersectingCountersAverage }} — Use the average ctr counter values in the intersecting bins.
 

--- a/catboost/docs/en/presets.yaml
+++ b/catboost/docs/en/presets.yaml
@@ -512,7 +512,7 @@ default:
   java__hashcategoricalfeature: hashCategoricalFeature(String)
   title__export-to-core-ml: Export the model to Apple CoreML
   loss-function__params__greater-than: greater_than
-  ECtrTableMergePolicy__FailIfCtrsIntersects: FailIfCtrsIntersects
+  ECtrTableMergePolicy__FailIfCtrIntersects: FailIfCtrIntersects
   ECtrTableMergePolicy__LeaveMostDiversifiedTable: LeaveMostDiversifiedTable
   ECtrTableMergePolicy__IntersectingCountersAverage: IntersectingCountersAverage
   ECtrTableMergePolicy__KeepAllTables: KeepAllTables


### PR DESCRIPTION
Some of the docs reference `FailIfCtrsIntersects`, which doesn't exist in the code.

The correct name is `FailIfCtrIntersects`: 
```
❯ grep -r FailIfCtrIntersects .
./libs/model/ctr_provider.h:    FailIfCtrIntersects,
./libs/model/static_ctr_provider.cpp:            case ECtrTableMergePolicy::FailIfCtrIntersects:
./libs/model/static_ctr_provider.cpp:                throw TCatBoostException() << "FailIfCtrIntersects policy forbids model ctr tables intersection";
./R-package/man/catboost.sum_models.Rd:  \item 'FailIfCtrIntersects'
./R-package/R/catboost.R:#'   \item 'FailIfCtrIntersects'
./spark/catboost4j-spark/core/src/native_impl/catboost_enums.i:    FailIfCtrIntersects,
``` 

This fixes issue #2497 