### PR TITLE
Get train_dir from env. variables

### DIFF
--- a/catboost/R-package/R/catboost.R
+++ b/catboost/R-package/R/catboost.R
@@ -2340,7 +2340,7 @@ catboost.eval_metrics <- function(model, pool, metrics, ntree_start = 0L, ntree_
   params <- catboost.get_plain_params(model)
   train_dir <- params[['train_dir']]
   if (is.null(params[['train_dir']]))
-    train_dir <- 'catboost_info'
+    train_dir <- Sys.getenv('CATBOOST_INFO_DIR', 'catboost_info')
   result <- .Call("CatBoostEvalMetrics_R", model$cpp_obj$handle, pool, metrics,
                   ntree_start, ntree_end, eval_period,
                   thread_count, tmp_dir, train_dir)

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1467,7 +1467,7 @@ def _clear_training_files(train_dir):
 
 
 def _get_train_dir(params):
-    return params.get('train_dir', 'catboost_info')
+    return params.get('train_dir', os.getenv('CATBOOST_INFO_DIR', 'catboost_info'))
 
 
 def _get_catboost_widget(train_dirs):


### PR DESCRIPTION
Read the params value for `train_dir` from the `CATBOOST_TRAIN_DIR` env. variable or default back to `catboost_info` if not specified at all.

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
5. If you haven't already, sign [the Contributor License Agreement](https://yandex.ru/legal/cla/).
