### PR TITLE
Add functions for getting indices of features of different types to C API

### DIFF
--- a/catboost/libs/model/model.cpp
+++ b/catboost/libs/model/model.cpp
@@ -1341,6 +1341,46 @@ TVector<TString> GetModelUsedFeaturesNames(const TFullModel& model) {
     return result;
 }
 
+TVector<int> GetModelCatFeaturesIndices(const TFullModel& model) {
+    const auto features = model.ModelTrees->GetCatFeatures();
+    TVector<int> indices;
+    indices.reserve(features.size());
+    for (const auto& feature : features) {
+        indices.push_back(feature.Position.FlatIndex);
+    }
+    return indices;
+}
+
+TVector<int> GetModelFloatFeaturesIndices(const TFullModel& model) {
+    const auto features = model.ModelTrees->GetFloatFeatures();
+    TVector<int> indices;
+    indices.reserve(features.size());
+    for (const auto& feature : features) {
+        indices.push_back(feature.Position.FlatIndex);
+    }
+    return indices;
+}
+
+TVector<int> GetModelTextFeaturesIndices(const TFullModel& model) {
+    const auto features = model.ModelTrees->GetTextFeatures();
+    TVector<int> indices;
+    indices.reserve(features.size());
+    for (const auto& feature : features) {
+        indices.push_back(feature.Position.FlatIndex);
+    }
+    return indices;
+}
+
+TVector<int> GetModelEmbeddingFeaturesIndices(const TFullModel& model) {
+    const auto features = model.ModelTrees->GetEmbeddingFeatures();
+    TVector<int> indices;
+    indices.reserve(features.size());
+    for (const auto& feature : features) {
+        indices.push_back(feature.Position.FlatIndex);
+    }
+    return indices;
+}
+
 void SetModelExternalFeatureNames(const TVector<TString>& featureNames, TFullModel* model) {
     model->ModelTrees.GetMutable()->ApplyFeatureNames(featureNames);
 }

--- a/catboost/libs/model/model.cpp
+++ b/catboost/libs/model/model.cpp
@@ -1341,44 +1341,30 @@ TVector<TString> GetModelUsedFeaturesNames(const TFullModel& model) {
     return result;
 }
 
-TVector<int> GetModelCatFeaturesIndices(const TFullModel& model) {
-    const auto features = model.ModelTrees->GetCatFeatures();
+template <typename T>
+TVector<int> MakeIndicesVector(const TConstArrayRef<T>& features) {
     TVector<int> indices;
     indices.reserve(features.size());
     for (const auto& feature : features) {
         indices.push_back(feature.Position.FlatIndex);
     }
     return indices;
+}
+
+TVector<int> GetModelCatFeaturesIndices(const TFullModel& model) {
+    return MakeIndicesVector(model.ModelTrees->GetCatFeatures());
 }
 
 TVector<int> GetModelFloatFeaturesIndices(const TFullModel& model) {
-    const auto features = model.ModelTrees->GetFloatFeatures();
-    TVector<int> indices;
-    indices.reserve(features.size());
-    for (const auto& feature : features) {
-        indices.push_back(feature.Position.FlatIndex);
-    }
-    return indices;
+    return MakeIndicesVector(model.ModelTrees->GetFloatFeatures());
 }
 
 TVector<int> GetModelTextFeaturesIndices(const TFullModel& model) {
-    const auto features = model.ModelTrees->GetTextFeatures();
-    TVector<int> indices;
-    indices.reserve(features.size());
-    for (const auto& feature : features) {
-        indices.push_back(feature.Position.FlatIndex);
-    }
-    return indices;
+    return MakeIndicesVector(model.ModelTrees->GetTextFeatures());
 }
 
 TVector<int> GetModelEmbeddingFeaturesIndices(const TFullModel& model) {
-    const auto features = model.ModelTrees->GetEmbeddingFeatures();
-    TVector<int> indices;
-    indices.reserve(features.size());
-    for (const auto& feature : features) {
-        indices.push_back(feature.Position.FlatIndex);
-    }
-    return indices;
+    return MakeIndicesVector(model.ModelTrees->GetEmbeddingFeatures());
 }
 
 void SetModelExternalFeatureNames(const TVector<TString>& featureNames, TFullModel* model) {

--- a/catboost/libs/model/model.h
+++ b/catboost/libs/model/model.h
@@ -1384,6 +1384,14 @@ TFullModel DeserializeModel(const TString& serializedModel);
 
 TVector<TString> GetModelUsedFeaturesNames(const TFullModel& model);
 
+TVector<int> GetModelCatFeaturesIndices(const TFullModel& model);
+
+TVector<int> GetModelFloatFeaturesIndices(const TFullModel& model);
+
+TVector<int> GetModelTextFeaturesIndices(const TFullModel& model);
+
+TVector<int> GetModelEmbeddingFeaturesIndices(const TFullModel& model);
+
 void SetModelExternalFeatureNames(const TVector<TString>& featureNames, TFullModel* model);
 
 TFullModel SumModels(

--- a/catboost/libs/model/ut/model_metadata_ut.cpp
+++ b/catboost/libs/model/ut/model_metadata_ut.cpp
@@ -145,7 +145,7 @@ Y_UNIT_TEST_SUITE(TModelTreesMetadata) {
         UNIT_ASSERT_EQUAL(model.GetNumCatFeatures(), model.GetMinimalSufficientCatFeaturesVectorSize());
 
         floatIndices = GetModelFloatFeaturesIndices(model);
-        expectedFloatIndices = {2, 4};
+        expectedFloatIndices = {0, 4};
         UNIT_ASSERT_EQUAL(floatIndices.size(), expectedFloatIndices.size());
         for (size_t i = 0; i != floatIndices.size(); ++i) {
             UNIT_ASSERT_EQUAL(expectedFloatIndices[i], floatIndices[i]);

--- a/catboost/libs/model/ut/model_metadata_ut.cpp
+++ b/catboost/libs/model/ut/model_metadata_ut.cpp
@@ -65,6 +65,40 @@ Y_UNIT_TEST_SUITE(TModelTreesMetadata) {
                 }
             }
         );
+        trees->SetTextFeatures(
+            {
+                TTextFeature {
+                    false,
+                    0,
+                    10,
+                    ""
+                },
+                 TTextFeature {
+                    true,
+                    1,
+                    12,
+                    ""
+                }
+            }
+        );
+        trees->SetEmbeddingFeatures(
+            {
+                TEmbeddingFeature {
+                    true,
+                    0,
+                    11,
+                    "",
+                    0
+                },
+                TEmbeddingFeature {
+                    false,
+                    1,
+                    13,
+                    "",
+                    0
+                }
+            }
+        );
         model.UpdateDynamicData();
         model.UpdateDynamicData();// we run update metadata to detect non zeroing of some counters
         UNIT_ASSERT_EQUAL(model.GetMinimalSufficientFloatFeaturesVectorSize(), 3);
@@ -73,6 +107,35 @@ Y_UNIT_TEST_SUITE(TModelTreesMetadata) {
         UNIT_ASSERT_EQUAL(model.GetUsedCatFeaturesCount(), 3);
         UNIT_ASSERT_EQUAL(model.GetNumFloatFeatures(), 4);
         UNIT_ASSERT_EQUAL(model.GetNumCatFeatures(), 6);
+
+        auto floatIndices = GetModelFloatFeaturesIndices(model);
+        TVector<int> expectedFloatIndices = {0, 2, 4, 6};
+        UNIT_ASSERT_EQUAL(floatIndices.size(), expectedFloatIndices.size());
+        for (size_t i = 0; i != floatIndices.size(); ++i) {
+            UNIT_ASSERT_EQUAL(expectedFloatIndices[i], floatIndices[i]);
+        }
+
+        auto categoryIndices = GetModelCatFeaturesIndices(model);
+        TVector<int> expectedCategoryIndices = {1, 3, 5, 7, 8, 9};
+        UNIT_ASSERT_EQUAL(categoryIndices.size(), expectedCategoryIndices.size());
+        for (size_t i = 0; i != categoryIndices.size(); ++i) {
+            UNIT_ASSERT_EQUAL(expectedCategoryIndices[i], categoryIndices[i]);
+        }
+
+        auto textIndices = GetModelTextFeaturesIndices(model);
+        TVector<int> expectedTextIndices = {10, 12};
+        UNIT_ASSERT_EQUAL(categoryIndices.size(), expectedCategoryIndices.size());
+        for (size_t i = 0; i != textIndices.size(); ++i) {
+            UNIT_ASSERT_EQUAL(expectedTextIndices[i], textIndices[i]);
+        }
+
+        auto embeddingIndices = GetModelEmbeddingFeaturesIndices(model);
+        TVector<int> expectedEmbeddingIndices = {11, 13};
+        UNIT_ASSERT_EQUAL(embeddingIndices.size(), expectedEmbeddingIndices.size());
+        for (size_t i = 0; i != embeddingIndices.size(); ++i) {
+            UNIT_ASSERT_EQUAL(expectedEmbeddingIndices[i], embeddingIndices[i]);
+        }
+
         trees->DropUnusedFeatures();
         UNIT_ASSERT_EQUAL(model.GetMinimalSufficientFloatFeaturesVectorSize(), 3);
         UNIT_ASSERT_EQUAL(model.GetMinimalSufficientCatFeaturesVectorSize(), 5);
@@ -80,5 +143,33 @@ Y_UNIT_TEST_SUITE(TModelTreesMetadata) {
         UNIT_ASSERT_EQUAL(model.GetUsedCatFeaturesCount(), 3);
         UNIT_ASSERT_EQUAL(model.GetNumFloatFeatures(), model.GetMinimalSufficientFloatFeaturesVectorSize());
         UNIT_ASSERT_EQUAL(model.GetNumCatFeatures(), model.GetMinimalSufficientCatFeaturesVectorSize());
+
+        floatIndices = GetModelFloatFeaturesIndices(model);
+        expectedFloatIndices = {2, 4};
+        UNIT_ASSERT_EQUAL(floatIndices.size(), expectedFloatIndices.size());
+        for (size_t i = 0; i != floatIndices.size(); ++i) {
+            UNIT_ASSERT_EQUAL(expectedFloatIndices[i], floatIndices[i]);
+        }
+
+        categoryIndices = GetModelCatFeaturesIndices(model);
+        expectedCategoryIndices = {3, 5, 8};
+        UNIT_ASSERT_EQUAL(categoryIndices.size(), expectedCategoryIndices.size());
+        for (size_t i = 0; i != categoryIndices.size(); ++i) {
+            UNIT_ASSERT_EQUAL(expectedCategoryIndices[i], categoryIndices[i]);
+        }
+
+        textIndices = GetModelTextFeaturesIndices(model);
+        expectedTextIndices = {12};
+        UNIT_ASSERT_EQUAL(categoryIndices.size(), expectedCategoryIndices.size());
+        for (size_t i = 0; i != textIndices.size(); ++i) {
+            UNIT_ASSERT_EQUAL(expectedTextIndices[i], textIndices[i]);
+        }
+
+        embeddingIndices = GetModelEmbeddingFeaturesIndices(model);
+        expectedEmbeddingIndices = {11};
+        UNIT_ASSERT_EQUAL(embeddingIndices.size(), expectedEmbeddingIndices.size());
+        for (size_t i = 0; i != embeddingIndices.size(); ++i) {
+            UNIT_ASSERT_EQUAL(expectedEmbeddingIndices[i], embeddingIndices[i]);
+        }
     }
 }

--- a/catboost/libs/model_interface/c_api.cpp
+++ b/catboost/libs/model_interface/c_api.cpp
@@ -888,8 +888,7 @@ CATBOOST_API bool GetModelUsedFeaturesNames(ModelCalcerHandle* modelHandle, char
     return true;
 }
 
-CATBOOST_API bool GetCatFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
-    const auto featureIndices = GetModelCatFeaturesIndices(*FULL_MODEL_PTR(modelHandle));
+bool GetFeatureIndices(const TVector<int>& featureIndices, int** indices, size_t* count) {
     *indices = (int*)malloc(sizeof(int) * featureIndices.size());
     if (!*indices) {
         return false;
@@ -898,48 +897,54 @@ CATBOOST_API bool GetCatFeatureIndices(ModelCalcerHandle* modelHandle, int** ind
     *count = featureIndices.size();
     for (size_t i = 0; i != featureIndices.size(); ++i) {
         (*indices)[i] = featureIndices[i];
+    }
+    return true;
+}
+
+CATBOOST_API bool GetCatFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
+    try {
+        if (!GetFeatureIndices(GetModelCatFeaturesIndices(*FULL_MODEL_PTR(modelHandle)), indices, count)) {
+            return false;
+        }
+    } catch(...) {
+        Singleton<TErrorMessageHolder>()->Message = CurrentExceptionMessage();
+        return false;
     }
     return true;
 }
 
 CATBOOST_API bool GetFloatFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
-    const auto featureIndices = GetModelFloatFeaturesIndices(*FULL_MODEL_PTR(modelHandle));
-    *indices = (int*)malloc(sizeof(int) * featureIndices.size());
-    if (!*indices) {
+    try {
+        if (!GetFeatureIndices(GetModelFloatFeaturesIndices(*FULL_MODEL_PTR(modelHandle)), indices, count)) {
+            return false;
+        }
+    } catch(...) {
+        Singleton<TErrorMessageHolder>()->Message = CurrentExceptionMessage();
         return false;
-    }
-
-    *count = featureIndices.size();
-    for (size_t i = 0; i != featureIndices.size(); ++i) {
-        (*indices)[i] = featureIndices[i];
     }
     return true;
 }
 
 CATBOOST_API bool GetTextFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
-    const auto featureIndices = GetModelTextFeaturesIndices(*FULL_MODEL_PTR(modelHandle));
-    *indices = (int*)malloc(sizeof(int) * featureIndices.size());
-    if (!*indices) {
+    try {
+        if (!GetFeatureIndices(GetModelTextFeaturesIndices(*FULL_MODEL_PTR(modelHandle)), indices, count)) {
+            return false;
+        }
+    } catch(...) {
+        Singleton<TErrorMessageHolder>()->Message = CurrentExceptionMessage();
         return false;
-    }
-
-    *count = featureIndices.size();
-    for (size_t i = 0; i != featureIndices.size(); ++i) {
-        (*indices)[i] = featureIndices[i];
     }
     return true;
 }
 
 CATBOOST_API bool GetEmbeddingFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
-    const auto featureIndices = GetModelEmbeddingFeaturesIndices(*FULL_MODEL_PTR(modelHandle));
-    *indices = (int*)malloc(sizeof(int) * featureIndices.size());
-    if (!*indices) {
+    try {
+        if (!GetFeatureIndices(GetModelEmbeddingFeaturesIndices(*FULL_MODEL_PTR(modelHandle)), indices, count)) {
+            return false;
+        }
+    } catch(...) {
+        Singleton<TErrorMessageHolder>()->Message = CurrentExceptionMessage();
         return false;
-    }
-
-    *count = featureIndices.size();
-    for (size_t i = 0; i != featureIndices.size(); ++i) {
-        (*indices)[i] = featureIndices[i];
     }
     return true;
 }

--- a/catboost/libs/model_interface/c_api.cpp
+++ b/catboost/libs/model_interface/c_api.cpp
@@ -888,5 +888,61 @@ CATBOOST_API bool GetModelUsedFeaturesNames(ModelCalcerHandle* modelHandle, char
     return true;
 }
 
+CATBOOST_API bool GetCatFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
+    const auto featureIndices = GetModelCatFeaturesIndices(*FULL_MODEL_PTR(modelHandle));
+    *indices = (int*)malloc(sizeof(int) * featureIndices.size());
+    if (!*indices) {
+        return false;
+    }
+
+    *count = featureIndices.size();
+    for (size_t i = 0; i != featureIndices.size(); ++i) {
+        (*indices)[i] = featureIndices[i];
+    }
+    return true;
+}
+
+CATBOOST_API bool GetFloatFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
+    const auto featureIndices = GetModelFloatFeaturesIndices(*FULL_MODEL_PTR(modelHandle));
+    *indices = (int*)malloc(sizeof(int) * featureIndices.size());
+    if (!*indices) {
+        return false;
+    }
+
+    *count = featureIndices.size();
+    for (size_t i = 0; i != featureIndices.size(); ++i) {
+        (*indices)[i] = featureIndices[i];
+    }
+    return true;
+}
+
+CATBOOST_API bool GetTextFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
+    const auto featureIndices = GetModelTextFeaturesIndices(*FULL_MODEL_PTR(modelHandle));
+    *indices = (int*)malloc(sizeof(int) * featureIndices.size());
+    if (!*indices) {
+        return false;
+    }
+
+    *count = featureIndices.size();
+    for (size_t i = 0; i != featureIndices.size(); ++i) {
+        (*indices)[i] = featureIndices[i];
+    }
+    return true;
+}
+
+CATBOOST_API bool GetEmbeddingFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count) {
+    const auto featureIndices = GetModelEmbeddingFeaturesIndices(*FULL_MODEL_PTR(modelHandle));
+    *indices = (int*)malloc(sizeof(int) * featureIndices.size());
+    if (!*indices) {
+        return false;
+    }
+
+    *count = featureIndices.size();
+    for (size_t i = 0; i != featureIndices.size(); ++i) {
+        (*indices)[i] = featureIndices[i];
+    }
+    return true;
+}
+
 
 }

--- a/catboost/libs/model_interface/c_api.h
+++ b/catboost/libs/model_interface/c_api.h
@@ -402,10 +402,30 @@ CATBOOST_API int GetIntegerCatFeatureHash(long long val);
 CATBOOST_API size_t GetFloatFeaturesCount(ModelCalcerHandle* modelHandle);
 
 /**
+ * Get expected indices of float features used in the model.
+ * indices array must be deallocated using free() after use.
+ * @param modelHandle model handle
+ * @param indices indices of the features
+ * @param count indices size
+ * @return true on success, false on error
+ */
+CATBOOST_API bool GetFloatFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count);
+
+/**
  * Get expected categorical feature count for model
  * @param calcer model handle
  */
 CATBOOST_API size_t GetCatFeaturesCount(ModelCalcerHandle* modelHandle);
+
+/**
+ * Get expected indices of category features used in the model.
+ * indices array must be deallocated using free() after use.
+ * @param modelHandle model handle
+ * @param indices indices of the features
+ * @param count indices size
+ * @return true on success, false on error
+ */
+CATBOOST_API bool GetCatFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count);
 
 /**
  * Get expected text feature count for model
@@ -414,10 +434,30 @@ CATBOOST_API size_t GetCatFeaturesCount(ModelCalcerHandle* modelHandle);
 CATBOOST_API size_t GetTextFeaturesCount(ModelCalcerHandle* modelHandle);
 
 /**
+ * Get expected indices of text features used in the model.
+ * indices array must be deallocated using free() after use.
+ * @param modelHandle model handle
+ * @param indices indices of the features
+ * @param count indices size
+ * @return true on success, false on error
+ */
+CATBOOST_API bool GetTextFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count);
+
+/**
  * Get expected embedding feature count for model
  * @param calcer model handle
  */
 CATBOOST_API size_t GetEmbeddingFeaturesCount(ModelCalcerHandle* modelHandle);
+
+/**
+ * Get expected indices of embedding features used in the model.
+ * indices array must be deallocated using free() after use.
+ * @param modelHandle model handle
+ * @param indices indices of the features
+ * @param count indices size
+ * @return true on success, false on error
+ */
+CATBOOST_API bool GetEmbeddingFeatureIndices(ModelCalcerHandle* modelHandle, int** indices, size_t* count);
 
 /**
  * Get number of trees in model

--- a/catboost/libs/model_interface/calcer.exports
+++ b/catboost/libs/model_interface/calcer.exports
@@ -49,3 +49,8 @@ C CheckModelMetadataHasKey
 C GetModelInfoValueSize
 C GetModelInfoValue
 C GetModelUsedFeaturesNames
+
+C GetCatFeatureIndices
+C GetFloatFeatureIndices
+C GetTextFeatureIndices
+C GetEmbeddingFeatureIndices


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.

I am adding methods for retrieving feature indices.
The Python API already has it, but the C API is missing it.
