### PR TITLE
Fixed bloating temp directory with copies of native libraries on Windows

### DIFF
--- a/catboost/jvm-packages/common/src/main/java/ai/catboost/common/NativeLib.java
+++ b/catboost/jvm-packages/common/src/main/java/ai/catboost/common/NativeLib.java
@@ -18,7 +18,7 @@ public class NativeLib {
     private static final String LOCK_EXT = ".lck";
 
     /**
-     * Load libName, first will try to load libName from default location then will try to load library from JAR.
+     * Load libName, first will try try to load libName from default location then will try to load library from JAR.
      *
      * @param libName
      * @throws IOException

--- a/catboost/jvm-packages/common/src/main/java/ai/catboost/common/NativeLib.java
+++ b/catboost/jvm-packages/common/src/main/java/ai/catboost/common/NativeLib.java
@@ -130,22 +130,21 @@ public class NativeLib {
 
         try (Stream<Path> dirList = Files.list(new File(System.getProperty("java.io.tmpdir")).toPath())) {
             dirList.filter(
-                            path ->
-                                    !path.getFileName().toString().endsWith(LOCK_EXT)
-                                            && path.getFileName()
-                                            .toString()
-                                            .startsWith(searchPattern))
-                    .forEach(
-                            nativeLib -> {
-                                Path lckFile = Paths.get(nativeLib + LOCK_EXT);
-                                if (Files.notExists(lckFile)) {
-                                    try {
-                                        Files.delete(nativeLib);
-                                    } catch (Exception e) {
-                                        logger.error("Failed to delete old native lib", e);
-                                    }
-                                }
-                            });
+                path -> !path.getFileName().toString().endsWith(LOCK_EXT)
+                    && path.getFileName()
+                        .toString()
+                        .startsWith(searchPattern))
+                .forEach(
+                    nativeLib -> {
+                        Path lckFile = Paths.get(nativeLib + LOCK_EXT);
+                        if (Files.notExists(lckFile)) {
+                            try {
+                                Files.delete(nativeLib);
+                            } catch (Exception e) {
+                                logger.error("Failed to delete old native lib", e);
+                            }
+                        }
+                    });
         } catch (IOException e) {
             logger.error("Failed to open directory", e);
         }

--- a/catboost/jvm-packages/common/src/test/java/ai/catboost/common/IteratorUtilsTest.java
+++ b/catboost/jvm-packages/common/src/test/java/ai/catboost/common/IteratorUtilsTest.java
@@ -1,85 +1,84 @@
 package ai.catboost.common;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 import org.apache.commons.math3.util.Precision;
 
+import junit.framework.TestCase;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import ai.catboost.common.IteratorUtils;
 
 public class IteratorUtilsTest {
     @Test
     public void testEmpty() {
-        assertTrue(
+        TestCase.assertTrue(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new int[0]).iterator(),
                 Arrays.stream(new int[0]).iterator(),
-                    Objects::equals
+                (l, r) -> l == r
             )
         );
     }
 
     @Test
     public void testEmptyAndNonEmpty() {
-        assertFalse(
+        TestCase.assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new int[] {4, 5, 6, 1}).iterator(),
                 Arrays.stream(new int[0]).iterator(),
-                    Objects::equals
+                (l, r) -> l == r
             )
         );
     }
 
     @Test
     public void testSameSizeAndEqual() {
-        assertTrue(
+        TestCase.assertTrue(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new String[] {"a", "b", "c"}).iterator(),
                 Arrays.stream(new String[] {"a", "b", "c"}).iterator(),
-                    String::equals
+                (l, r) -> l.equals(r)
             )
         );
     }
 
     @Test
     public void testSameSizeAndNonEqual() {
-        assertFalse(
+        TestCase.assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new int[] {4, 5, 6, 1}).iterator(),
                 Arrays.stream(new int[] {4, 5, 3, 1}).iterator(),
-                    Objects::equals
+                (l, r) -> l == r
             )
         );
     }
 
     @Test
     public void testDifferentSizeSamePrefix() {
-        assertFalse(
+        TestCase.assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new int[] {1, 2, 3, 4, 5}).iterator(),
                 Arrays.stream(new int[] {1, 2, 3}).iterator(),
-                    Objects::equals
+                (l, r) -> l == r
             )
         );
     }
 
     @Test
     public void testDifferentSizeDifferentPrefix() {
-        assertFalse(
+        TestCase.assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new String[] {"a", "z", "c", "d"}).iterator(),
                 Arrays.stream(new String[] {"a", "b", "c"}).iterator(),
-                    String::equals
+                (l, r) -> l.equals(r)
             )
         );
     }
 
     @Test
     public void testEqualWithPrecision() {
-        assertTrue(
+        TestCase.assertTrue(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new double[] {1.e-4, 1.0}).iterator(),
                 Arrays.stream(new double[] {1.e-5, 1.0}).iterator(),
@@ -90,7 +89,7 @@ public class IteratorUtilsTest {
 
     @Test
     public void testNonEqualWithPrecision() {
-        assertFalse(
+        TestCase.assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new double[] {1.e-4, 1.0}).iterator(),
                 Arrays.stream(new double[] {1.e-5, 1.0}).iterator(),

--- a/catboost/jvm-packages/common/src/test/java/ai/catboost/common/IteratorUtilsTest.java
+++ b/catboost/jvm-packages/common/src/test/java/ai/catboost/common/IteratorUtilsTest.java
@@ -1,5 +1,3 @@
-package ai.catboost.common;
-
 import java.util.Arrays;
 
 import org.apache.commons.math3.util.Precision;

--- a/catboost/jvm-packages/common/src/test/java/ai/catboost/common/IteratorUtilsTest.java
+++ b/catboost/jvm-packages/common/src/test/java/ai/catboost/common/IteratorUtilsTest.java
@@ -1,82 +1,85 @@
+package ai.catboost.common;
+
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.commons.math3.util.Precision;
 
-import junit.framework.TestCase;
 import org.junit.Test;
 
-import ai.catboost.common.IteratorUtils;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class IteratorUtilsTest {
     @Test
     public void testEmpty() {
-        TestCase.assertTrue(
+        assertTrue(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new int[0]).iterator(),
                 Arrays.stream(new int[0]).iterator(),
-                (l, r) -> l == r
+                    Objects::equals
             )
         );
     }
 
     @Test
     public void testEmptyAndNonEmpty() {
-        TestCase.assertFalse(
+        assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new int[] {4, 5, 6, 1}).iterator(),
                 Arrays.stream(new int[0]).iterator(),
-                (l, r) -> l == r
+                    Objects::equals
             )
         );
     }
 
     @Test
     public void testSameSizeAndEqual() {
-        TestCase.assertTrue(
+        assertTrue(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new String[] {"a", "b", "c"}).iterator(),
                 Arrays.stream(new String[] {"a", "b", "c"}).iterator(),
-                (l, r) -> l.equals(r)
+                    String::equals
             )
         );
     }
 
     @Test
     public void testSameSizeAndNonEqual() {
-        TestCase.assertFalse(
+        assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new int[] {4, 5, 6, 1}).iterator(),
                 Arrays.stream(new int[] {4, 5, 3, 1}).iterator(),
-                (l, r) -> l == r
+                    Objects::equals
             )
         );
     }
 
     @Test
     public void testDifferentSizeSamePrefix() {
-        TestCase.assertFalse(
+        assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new int[] {1, 2, 3, 4, 5}).iterator(),
                 Arrays.stream(new int[] {1, 2, 3}).iterator(),
-                (l, r) -> l == r
+                    Objects::equals
             )
         );
     }
 
     @Test
     public void testDifferentSizeDifferentPrefix() {
-        TestCase.assertFalse(
+        assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new String[] {"a", "z", "c", "d"}).iterator(),
                 Arrays.stream(new String[] {"a", "b", "c"}).iterator(),
-                (l, r) -> l.equals(r)
+                    String::equals
             )
         );
     }
 
     @Test
     public void testEqualWithPrecision() {
-        TestCase.assertTrue(
+        assertTrue(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new double[] {1.e-4, 1.0}).iterator(),
                 Arrays.stream(new double[] {1.e-5, 1.0}).iterator(),
@@ -87,7 +90,7 @@ public class IteratorUtilsTest {
 
     @Test
     public void testNonEqualWithPrecision() {
-        TestCase.assertFalse(
+        assertFalse(
             IteratorUtils.elementsEqual(
                 Arrays.stream(new double[] {1.e-4, 1.0}).iterator(),
                 Arrays.stream(new double[] {1.e-5, 1.0}).iterator(),


### PR DESCRIPTION
Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
5. If you haven't already, sign [the Contributor License Agreement](https://yandex.ru/legal/cla/).

Problem: when using catboost in Java a native library has to be loaded into JVM. To do so we extract corresponding native library into temp folder. After JVM shutdown this file stays there. In case when temp folder is system temp folder it may not be a problem. However when catboost used in managed environment like Application Server or Servlet Container, the temp directory will be the temp directory of this environment. Without any cleaning mechanism space on hard drive will be quickly bloated.

In this PR I suggest mechanism that deletes copies of native library in temp directory. To accomplish it I did the following changes:
1. Native libraries copies to temp directory with version.
2. Creating in temp directory empty file with library filename + .lck suffix
3. Before loading library scan temp directory. If we find file that has name and version that we about to load && corresponding .lck file does not exist then delete such file.

This algorithm will work every time JVM shutsdown gracefully. In case of sudden shutdown no remedy exists.

Why this algorithm will work? (Here is my explanation, but I am not 100% sure on it)
The problem is in the fact that native library that we copied to temp folder won't be deleted despite the fact that method deleteOnExit called. That happens because this file was loaded by System classloader and will be released only after System ClassLoader garbage collected. But GC of System ClassLoader means that JVM shut down.
But this won't happen to simple file which is .lck file.

Another approach to solve this problem is to load native library with other ClassLoader. I don't think this is a good idea.

The source of inspiration for this PR can be found here:  https://github.com/xerial/sqlite-jdbc/blob/master/src/main/java/org/sqlite/SQLiteJDBCLoader.java

In the attachment you can find two projects. JNA-WAR and JNA-JAR. Their intention is to reproduce the problem and check the solution. There are dependencies on catboost-prediction and sqllite. JNA-WAR should be run in Servlet Container. I tested on tomcat 10.
[jna_jar.zip](https://github.com/catboost/catboost/files/14837958/jna_jar.zip)
[jna_war.zip](https://github.com/catboost/catboost/files/14837959/jna_war.zip)
