### PR TITLE
Add 'APT_MULTI_PROBABILITY' to EApiPredictionType

### DIFF
--- a/catboost/libs/model_interface/c_api.h
+++ b/catboost/libs/model_interface/c_api.h
@@ -52,7 +52,8 @@ enum EApiPredictionType {
     APT_EXPONENT = 1,
     APT_RMSE_WITH_UNCERTAINTY = 2,
     APT_PROBABILITY = 3,
-    APT_CLASS = 4,
+    APT_MULTI_PROBABILITY = 4,
+    APT_CLASS = 5,
 };
 
 enum ECatBoostApiFormulaEvaluatorType {

--- a/catboost/libs/model_interface/c_api.h
+++ b/catboost/libs/model_interface/c_api.h
@@ -52,8 +52,8 @@ enum EApiPredictionType {
     APT_EXPONENT = 1,
     APT_RMSE_WITH_UNCERTAINTY = 2,
     APT_PROBABILITY = 3,
-    APT_MULTI_PROBABILITY = 4,
-    APT_CLASS = 5,
+    APT_CLASS = 4,
+    APT_MULTI_PROBABILITY = 5,
 };
 
 enum ECatBoostApiFormulaEvaluatorType {


### PR DESCRIPTION
Align `EApiPredictionType` enum in `catboost/libs/model_interface/c_api.h` with `NCB::NModelEvaluation::EPredictionType` in `catboost/libs/model/enums.h`.
