### PR TITLE
#2659 Add warning over missing pool in save_model

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -13,6 +13,7 @@ from collections import OrderedDict, defaultdict
 
 from six import iteritems, string_types, integer_types
 
+import textwrap
 import warnings
 import numpy as np
 import ctypes
@@ -3406,7 +3407,16 @@ class CatBoost(_CatBoostBase):
             raise CatBoostError("There is no trained model to use save_model(). Use fit() to train model. Then use this method.")
         if not isinstance(fname, PATH_TYPES):
             raise CatBoostError("Invalid fname type={}: must be str() or pathlib.Path().".format(type(fname)))
-        if pool is not None and not isinstance(pool, Pool):
+        if pool is None:
+            if format in ["cpp", "json", "python"]:
+                warn_msg = textwrap.dedent("""
+                    The "pool" parameter is required if the model contains categorical features \
+                    and the output format is cpp, python, or JSON. \
+                    Otherwise, hashes of the categorical values cannot be stored.
+                    Details: https://catboost.ai/en/docs/concepts/python-reference_catboostclassifier_save_model#pool
+                """)
+                warnings.warn(warn_msg)
+        elif not isinstance(pool, Pool):
             pool = Pool(
                 data=pool,
                 cat_features=self._get_cat_feature_indices() if not isinstance(pool, FeaturesData) else None,


### PR DESCRIPTION
If the concept is ok, then I can add tests if needed

Fix #2659

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
5. If you haven't already, sign [the Contributor License Agreement](https://yandex.ru/legal/cla/).
