### PR TITLE
fix: Correct plotting of trees with more than 1 output

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -4010,7 +4010,7 @@ class CatBoost(_CatBoostBase):
             return self._plot_oblivious_tree(splits, leaf_values)
         else:
             step_nodes = self._get_tree_step_nodes(tree_idx)
-            node_to_leaf = self._get_tree_node_to_leaf(tree_idx)
+            node_to_leaf = [int(entry / len(self.n_classes)) for entry in self._get_tree_node_to_leaf(tree_idx)]
             return self._plot_nonsymmetric_tree(splits, leaf_values, step_nodes, node_to_leaf)
 
     def _tune_hyperparams(self, param_grid, X, y=None, cv=3, n_iter=10, partition_random_seed=0,


### PR DESCRIPTION
Before submitting a pull request, please do the following steps:

I hereby agree to the terms of the CLA available at: [https://yandex.ru/legal/cla/?lang=en](https://yandex.ru/legal/cla/?lang=en).

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
5. If you haven't already, sign [the Contributor License Agreement](https://yandex.ru/legal/cla/).

#------

If a tree is trained with multiple outputs the plot_tree doesnt work for all trees because the indeces are too big.
I tested this with multiple outputs and multiple numbers of outputs.
I attached a minimal example which crashes:

```
import numpy as np
from catboost import CatBoostClassifier, Pool
from catboost.datasets import titanic

titanic_df = titanic()

y = titanic_df[0][["Survived", "Sex"]]
y.loc[:, "Sex"] = y.loc[:, "Sex"].map({"male": 1, "female": 0})
X = titanic_df[0].drop(["Survived", "Sex"], axis=1)

is_cat = X.dtypes != float
for feature, feat_is_cat in is_cat.to_dict().items():
    if feat_is_cat:
        X[feature].fillna("NAN", inplace=True)

cat_features_index = np.where(is_cat)[0]
pool = Pool(X, y, cat_features=cat_features_index, feature_names=list(X.columns))

parameters = {
    "iterations": 10,
    "depth": 3,
    "grow_policy": "Depthwise",
    "loss_function": "MultiLogloss",
    "random_seed": 0,
}
model = CatBoostClassifier(**parameters)
model.fit(pool)
model.plot_tree(0)
```