### PR TITLE
CLI --init-model parameter

### DIFF
--- a/catboost/libs/train_lib/train_model.cpp
+++ b/catboost/libs/train_lib/train_model.cpp
@@ -1271,6 +1271,11 @@ void TrainModel(
         needFstr = false;
     }
 
+    TMaybe<TFullModel> initModel;
+    if (loadOptions.InitModelPath) {
+        initModel = ReadModel(loadOptions.InitModelPath.Path, modelFormat);
+    }
+
     TMaybe<TPrecomputedOnlineCtrData> precomputedSingleOnlineCtrDataForSingleFold;
     if (loadOptions.PrecomputedMetadataFile) {
         precomputedSingleOnlineCtrDataForSingleFold = ReadPrecomputedOnlineCtrMetaData(
@@ -1336,7 +1341,7 @@ void TrainModel(
         /*callbackDescriptor*/ Nothing(),
         std::move(pools),
         std::move(precomputedSingleOnlineCtrDataForSingleFold),
-        /*initModel*/ Nothing(),
+        std::move(initModel),
         /*initLearnProgress*/ nullptr,
         &loadOptions,
         /*outputModelPath*/ "",

--- a/catboost/private/libs/app_helpers/bind_options.cpp
+++ b/catboost/private/libs/app_helpers/bind_options.cpp
@@ -76,6 +76,10 @@ void BindQuantizerPoolLoadParams(NLastGetopt::TOpts* parser, NCatboostOptions::T
 void BindPoolLoadParams(NLastGetopt::TOpts* parser, NCatboostOptions::TPoolLoadParams* loadParamsPtr) {
     BindQuantizerPoolLoadParams(parser, loadParamsPtr);
 
+    parser->AddLongOption("init-model", "Init model path")
+      .OptionalArgument("PATH").StoreResult(&loadParamsPtr->InitModelPath)
+      .Help("Init model path");
+
     parser->AddLongOption("cv-no-shuffle", "Do not shuffle dataset before cross-validation")
       .NoArgument()
       .Handler0([loadParamsPtr]() {

--- a/catboost/private/libs/options/load_options.h
+++ b/catboost/private/libs/options/load_options.h
@@ -28,6 +28,7 @@ namespace NCatboostOptions {
     };
 
     struct TPoolLoadParams {
+        NCB::TPathWithScheme InitModelPath;
         TCvDataPartitionParams CvParams;
 
         TColumnarPoolFormatParams ColumnarPoolFormatParams;


### PR DESCRIPTION
I am sorry about not doing the following steps right now and will do them tomorrow, but I wanted to show this and gather some feedback in advance.
I am exposing this parameter, so it would be possible to implement checkpoints in `ai.catboost.spark.CatBoostPredictorTrait#fit` for it to be durable to our Spark cluster freeing spot-VMs.

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
5. If you haven't already, sign [the Contributor License Agreement](https://yandex.ru/legal/cla/).
