### PR TITLE
Introducing CatBoost Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![GitHub issues](https://img.shields.io/github/issues/catboost/catboost.svg)](https://github.com/catboost/catboost/issues)
 [![Telegram](https://img.shields.io/badge/chat-on%20Telegram-2ba2d9.svg)](https://t.me/catboost_en)
 [![Twitter](https://img.shields.io/badge/@CatBoostML--_.svg?style=social&logo=twitter)](https://twitter.com/CatBoostML)
+[![](https://img.shields.io/badge/Gurubase-Ask%20CatBoost%20Guru-006BFF)](https://gurubase.io/g/catboost)
 
 CatBoost is a machine learning method based on [gradient boosting](https://en.wikipedia.org/wiki/Gradient_boosting) over decision trees.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [CatBoost Guru](https://gurubase.io/g/catboost) to Gurubase. CatBoost Guru uses the data from this repo and data from the [docs](https://catboost.ai/en/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "CatBoost Guru", which highlights that CatBoost now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable CatBoost Guru in Gurubase, just let me know that's totally fine.