### PR TITLE
Adapt to new hyperopt versions: Changed np.random.RandomState to np.random.default_rng

### DIFF
--- a/catboost/tutorials/classification/classification_with_parameter_tuning_tutorial.ipynb
+++ b/catboost/tutorials/classification/classification_with_parameter_tuning_tutorial.ipynb
@@ -575,7 +575,7 @@
     "        space=parameter_space,\n",
     "        algo=hyperopt.rand.suggest,\n",
     "        max_evals=max_evals,\n",
-    "        rstate=np.random.RandomState(seed=20181224))\n",
+    "        rstate=np.random.default_rng(seed=20181224))\n",
     "    return best\n",
     "\n",
     "def train_best_model(X, y, const_params, max_evals=100, use_default=False):\n",

--- a/catboost/tutorials/hyperparameters_tuning/hyperparameters_tuning_using_optuna_and_hyperopt.ipynb
+++ b/catboost/tutorials/hyperparameters_tuning/hyperparameters_tuning_using_optuna_and_hyperopt.ipynb
@@ -802,7 +802,7 @@
     "    space=space,\n",
     "    algo=tpe.suggest,\n",
     "    max_evals=20,\n",
-    "    rstate=np.random.RandomState(seed=123))"
+    "    rstate=np.random.default_rng(seed=123))"
    ]
   },
   {
@@ -995,7 +995,7 @@
     "    space=space,\n",
     "    algo=tpe.suggest,\n",
     "    max_evals=20,\n",
-    "    rstate=np.random.RandomState(seed=123))"
+    "    rstate=np.random.default_rng(seed=123))"
    ]
   },
   {

--- a/catboost/tutorials/python_tutorial.ipynb
+++ b/catboost/tutorials/python_tutorial.ipynb
@@ -1304,7 +1304,7 @@
     }
    ],
    "source": [
-    "from numpy.random import RandomState\n",
+    "from numpy.random import default_rng\n",
     "\n",
     "params_space = {\n",
     "    'l2_leaf_reg': hyperopt.hp.qloguniform('l2_leaf_reg', 0, 2, 1),\n",
@@ -1319,7 +1319,7 @@
     "    algo=hyperopt.tpe.suggest,\n",
     "    max_evals=50,\n",
     "    trials=trials,\n",
-    "    rstate=RandomState(123)\n",
+    "    rstate=default_rng(123)\n",
     ")\n",
     "\n",
     "print(best)"


### PR DESCRIPTION
Fixing #2759 following resolution of the same [issue](https://github.com/hyperopt/hyperopt/issues/838) in `hyperopt` library.


`numpy.random.RandomState` was deprecated