### PR TITLE
fixed clippy lint

### DIFF
--- a/catboost/rust-package/src/error.rs
+++ b/catboost/rust-package/src/error.rs
@@ -1,4 +1,3 @@
-use catboost_sys;
 use std::ffi::CStr;
 use std::fmt;
 

--- a/catboost/rust-package/src/features.rs
+++ b/catboost/rust-package/src/features.rs
@@ -1,9 +1,7 @@
-
 use std::ffi::CString;
 
 #[derive(Default)]
-pub struct EmptyFloatFeatures {
-}
+pub struct EmptyFloatFeatures {}
 
 impl AsRef<[Vec<f32>]> for EmptyFloatFeatures {
     fn as_ref(&self) -> &[Vec<f32>] {
@@ -12,8 +10,7 @@ impl AsRef<[Vec<f32>]> for EmptyFloatFeatures {
 }
 
 #[derive(Default)]
-pub struct EmptyCatFeatures {
-}
+pub struct EmptyCatFeatures {}
 
 impl AsRef<[Vec<String>]> for EmptyCatFeatures {
     fn as_ref(&self) -> &[Vec<String>] {
@@ -22,8 +19,7 @@ impl AsRef<[Vec<String>]> for EmptyCatFeatures {
 }
 
 #[derive(Default)]
-pub struct EmptyTextFeatures {
-}
+pub struct EmptyTextFeatures {}
 
 impl AsRef<[Vec<CString>]> for EmptyTextFeatures {
     fn as_ref(&self) -> &[Vec<CString>] {
@@ -32,8 +28,7 @@ impl AsRef<[Vec<CString>]> for EmptyTextFeatures {
 }
 
 #[derive(Default)]
-pub struct EmptyEmbeddingFeatures {
-}
+pub struct EmptyEmbeddingFeatures {}
 
 impl AsRef<[Vec<Vec<f32>>]> for EmptyEmbeddingFeatures {
     fn as_ref(&self) -> &[Vec<Vec<f32>>] {
@@ -41,36 +36,39 @@ impl AsRef<[Vec<Vec<f32>>]> for EmptyEmbeddingFeatures {
     }
 }
 
- pub struct ObjectsOrderFeatures<
-    /// must provide 2-level dereferencing to f32. Outer is by-object, inner is by float feature
+pub struct ObjectsOrderFeatures<
+    // must provide 2-level dereferencing to f32. Outer is by-object, inner is by float feature
     TFloatFeatures = EmptyFloatFeatures,
-
-    /// must provide 2-level dereferencing to str. Outer is by-object, inner is by cat feature
+    // must provide 2-level dereferencing to str. Outer is by-object, inner is by cat feature
     TCatFeatures = EmptyCatFeatures,
-
-    /// must provide 2-level dereferencing to CStr. Outer is by-object, inner is by cat feature
-    /// Note: CStr is used because that's what CatBoost's C API functions accept this format for now.
+    // must provide 2-level dereferencing to CStr. Outer is by-object, inner is by cat feature
+    // Note: CStr is used because that's what CatBoost's C API functions accept this format for now.
     TTextFeatures = EmptyTextFeatures,
-
-    /// must provide 3-level dereferencing to f32. Levels are: by-object, by-embedding, index in embedding
+    // must provide 3-level dereferencing to f32. Levels are: by-object, by-embedding, index in embedding
     TEmbeddingFeatures = EmptyEmbeddingFeatures,
 > {
-  pub float_features: TFloatFeatures,
-  pub cat_features: TCatFeatures,
-  pub text_features: TTextFeatures,
-  pub embedding_features: TEmbeddingFeatures
+    pub float_features: TFloatFeatures,
+    pub cat_features: TCatFeatures,
+    pub text_features: TTextFeatures,
+    pub embedding_features: TEmbeddingFeatures,
 }
 
 
 impl ObjectsOrderFeatures<EmptyFloatFeatures, EmptyCatFeatures, EmptyTextFeatures, EmptyEmbeddingFeatures>
 {
     pub fn new() -> Self {
-        ObjectsOrderFeatures{
-            float_features: EmptyFloatFeatures{},
-            cat_features: EmptyCatFeatures{},
-            text_features: EmptyTextFeatures{},
-            embedding_features: EmptyEmbeddingFeatures{}
+        ObjectsOrderFeatures {
+            float_features: EmptyFloatFeatures {},
+            cat_features: EmptyCatFeatures {},
+            text_features: EmptyTextFeatures {},
+            embedding_features: EmptyEmbeddingFeatures {},
         }
+    }
+}
+
+impl Default for ObjectsOrderFeatures<EmptyFloatFeatures, EmptyCatFeatures, EmptyTextFeatures, EmptyEmbeddingFeatures> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/catboost/rust-package/src/model.rs
+++ b/catboost/rust-package/src/model.rs
@@ -153,7 +153,7 @@ impl Model {
             .map(|object_texts_ptrs: &mut Vec<*const i8>| object_texts_ptrs.as_mut_ptr())
             .collect::<Vec<_>>();
 
-        let mut embedding_dimensions = if features.embedding_features.as_ref().len() > 0 {
+        let mut embedding_dimensions = if !features.embedding_features.as_ref().is_empty() {
             features.embedding_features.as_ref()[0].as_ref().iter()
                 .map(|x| x.as_ref().len())
                 .collect::<Vec<_>>()
@@ -216,8 +216,8 @@ impl Model {
     ) -> CatBoostResult<Vec<f64>> {
         self.predict(
             ObjectsOrderFeatures{
-                float_features: float_features,
-                cat_features: cat_features,
+                float_features,
+                cat_features,
                 text_features: EmptyTextFeatures{},
                 embedding_features: EmptyEmbeddingFeatures{}
             }

--- a/catboost/rust-package/src/model.rs
+++ b/catboost/rust-package/src/model.rs
@@ -4,7 +4,6 @@ use crate::features::{
     EmptyTextFeatures,
     EmptyEmbeddingFeatures
 };
-use catboost_sys;
 use std::ffi::{CStr,CString};
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;


### PR DESCRIPTION
I used catboost lib as third party. But when i run `cargo clippy` i got linter errors
```
1) you should consider adding a `Default` implementation for `ObjectsOrderFeatures<EmptyFloatFeatures, EmptyCatFeatures, EmptyTextFeatures, EmptyEmbeddingFeatures>`

2) warning: redundant field names in struct initialization

3)warning: length comparison to zero

 help: using `!is_empty` is clearer and more explicit: `!features.embedding_features.as_ref().is_empty()`

```
after fix

```
cargo clippy
    Checking catboost v0.1.0 (/catboost/catboost/rust-package)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s
```

I agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru .
