### PR TITLE
Fix workers hanging

### DIFF
--- a/catboost/spark/catboost4j-spark/core/src/main/scala/ai/catboost/spark/impl/Workers.scala
+++ b/catboost/spark/catboost4j-spark/core/src/main/scala/ai/catboost/spark/impl/Workers.scala
@@ -94,7 +94,8 @@ private[spark] class CatBoostWorker(partitionId : Int) extends Logging {
 
       val workerListeningPort = if (workerListeningPortParam != 0) { workerListeningPortParam } else { TrainingDriver.getWorkerPort() }
 
-      val ecs = new ExecutorCompletionService[Unit](Executors.newFixedThreadPool(2))
+      val service = Executors.newFixedThreadPool(2)
+      val ecs = new ExecutorCompletionService[Unit](service)
 
       val partitionId = this.partitionId
       val sendWorkerInfoFuture = ecs.submit(
@@ -125,6 +126,8 @@ private[spark] class CatBoostWorker(partitionId : Int) extends Logging {
         },
         ()
       )
+
+      service.shutdown()
 
       try {
         impl.Helpers.waitForTwoFutures(

--- a/catboost/spark/catboost4j-spark/core/src/test/scala/ai/catboost/spark/CatBoostClassifierTest.scala
+++ b/catboost/spark/catboost4j-spark/core/src/test/scala/ai/catboost/spark/CatBoostClassifierTest.scala
@@ -24,6 +24,9 @@ class CatBoostClassifierTest {
   @Rule
   def temporaryFolder = _temporaryFolder
 
+  @Rule
+  def processingVerifier = ProcessingFinishedVerifier
+
 
   @Test
   @throws(classOf[Exception])

--- a/catboost/spark/catboost4j-spark/core/src/test/scala/ai/catboost/spark/CatBoostRegressorTest.scala
+++ b/catboost/spark/catboost4j-spark/core/src/test/scala/ai/catboost/spark/CatBoostRegressorTest.scala
@@ -30,6 +30,9 @@ class CatBoostRegressorTest {
   @Rule
   def temporaryFolder = _temporaryFolder
 
+  @Rule
+  def processingVerfier = ProcessingFinishedVerifier
+
 
   @Test
   @throws(classOf[Exception])

--- a/catboost/spark/catboost4j-spark/core/src/test/scala/ai/catboost/spark/ProcessingFinishedVerifier.scala
+++ b/catboost/spark/catboost4j-spark/core/src/test/scala/ai/catboost/spark/ProcessingFinishedVerifier.scala
@@ -1,0 +1,18 @@
+package ai.catboost.spark;
+
+import org.junit.rules.Verifier
+import org.junit.Assert
+
+
+object ProcessingFinishedVerifier extends Verifier {
+override def verify(): Unit = {
+    val runningNonDaemonThreads = Thread.getAllStackTraces.keySet.stream
+      .filter(t => !t.isDaemon && t != Thread.currentThread())
+      .map[String](_.getName)
+      .toArray
+    if (runningNonDaemonThreads.nonEmpty) {
+      Assert.fail(s"Some non-daemon threads are still running: ${runningNonDaemonThreads.mkString(", ")}")
+    }
+  }
+}
+


### PR DESCRIPTION
This PR aims to fix the issue of hanging catboost workers leading to spark applications can't exit properly (#2151, #2744).

The root cause is that the internal CatBoostWorker thread pool is never shutdown.

The unit tests are unable to catch this kind of issues, since the maven surefire plugin shuts forked JVM down, so all non daemon threads die. A junit verifier is added to check for non daemon threads that are still running at the end of the test case.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en