### PR TITLE
fix a typo in core.py

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1936,7 +1936,7 @@ class CatBoostClassifier(CatBoost):
         Poisson bootstrap is supported only on GPU.
 
     subsample : float, [default=None]
-        Sample rate for bagging. This parameter can be used Poisson or Bernoully bootstrap types.
+        Sample rate for bagging. This parameter can be used Poisson or Bernoulli bootstrap types.
 
     dev_score_calc_obj_block_size: int, [default=5000000]
         CPU only. Size of block of samples in score calculation. Should be > 0


### PR DESCRIPTION
Bernoulli is mistyped as Bernoully on line 1939 in core.py
