### PR TITLE
Fix get_catboost_version function for python 3.13

### DIFF
--- a/catboost/python-package/setup.py
+++ b/catboost/python-package/setup.py
@@ -201,8 +201,10 @@ def emph(s):
 
 def get_catboost_version():
     version_py = os.path.join('catboost', 'version.py')
-    exec(compile(open(version_py).read(), version_py, 'exec'))
-    return locals()['VERSION']
+    d = {}
+    with open(version_py) as f:
+        exec(compile(f.read(), version_py, "exec"), globals(), d)
+    return d['VERSION']
 
 
 class OptionsHelper(object):


### PR DESCRIPTION
This PR is to fix #2748

Use a dictionary to get the VERSION number in `get_catboost_version` function instead of locals as recommended [here](https://github.com/python/cpython/issues/118888#issuecomment-2104944287)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
