### PR TITLE
Fix R build on MacOS arm64

### DIFF
--- a/catboost/R-package/DESCRIPTION
+++ b/catboost/R-package/DESCRIPTION
@@ -54,3 +54,4 @@ BugReports: https://github.com/catboost/catboost/issues
 Suggests: caret, testthat, tibble, e1071
 Biarch: FALSE
 Encoding: UTF-8
+StagedInstall: FALSE


### PR DESCRIPTION
This fixes the problem that causes the package to fail installation on arm64 MacOS machines:

```
   ===== ./catboost.Rcheck/00install.out =====
  * installing *source* package ‘catboost’ ...
  ** using staged installation
  checking for R_HOME... /Library/Frameworks/R.framework/Resources
  checking for R... /Library/Frameworks/R.framework/Resources/bin/R
  *** creating .so -> .dylib symlink for working with different R installations
  checking for local CATBOOST_DYNLIB... no
  checking whether we can fetch CatBoost dynlib... downloading CatBoost (libcatboostr.dylib - v1.2.7)
  trying URL 'https://github.com/catboost/catboost/releases/download/v1.2.7/libcatboostr-darwin-universal2-v1.2.7.dylib'
  Content type 'application/octet-stream' length 62835520 bytes (59.9 MB)
  ==================================================
  downloaded 59.9 MB
  
  CatBoost fetch successful
  configure: creating ./config.status
  ** libs
  make: Nothing to be done for `all'.
  installing to /Users/runner/work/mlr-org/mlr-org/catboost.Rcheck/00LOCK-catboost/00new/catboost/libs
  ** R
  ** inst
  ** byte-compile and prepare package for lazy loading
  ** help
  *** installing help indices
  ** building package indices
  ** testing if installed package can be loaded from temporary location
  ** checking absolute paths in shared objects and dynamic libraries
  ERROR: some hard-coded temporary paths could not be fixed
  * removing ‘/Users/runner/work/mlr-org/mlr-org/catboost.Rcheck/catboost’
  ```

A better solution is to use a static library for libcatboostr instead of a dynamic one, but in the mean while this works.
