### PR TITLE
Use core::ffi::c_char instead if unportable i8. Fixes build on arm64: #2890.

### DIFF
--- a/catboost/rust-package/Cargo.toml
+++ b/catboost/rust-package/Cargo.toml
@@ -3,6 +3,7 @@ name = "catboost"
 version = "0.1.0"
 authors = ["Sergey Kiselev <kiselev.sg@gmail.com>"]
 edition = "2018"
+rust-version = "1.64"
 
 [dependencies]
 catboost-sys = { path = "catboost-sys", version = "0.1"}

--- a/catboost/rust-package/README.md
+++ b/catboost/rust-package/README.md
@@ -3,6 +3,8 @@ CatBoost Rust Package
 
 ### Prerequisites
 
+The minimal supported Rust version is 1.64.0 .
+
 CatBoost Rust package uses `catboost-sys` crate inside that is a wrapper around [`libcatboostmodel` library](https://catboost.ai/docs/en/concepts/c-plus-plus-api_dynamic-c-pluplus-wrapper) with an exposed C API.
 In order to build it some environment setup is necessary. Modern versions of CatBoost use CMake build system, build environment setup for CMake is described [here](https://catboost.ai/docs/en/installation/build-environment-setup-for-cmake), CatBoost versions before 1.2 used Ya Make build system, build environment setup for YaMake is described [here](https://catboost.ai/docs/en/installation/build-environment-setup-for-ya-make).
 

--- a/catboost/rust-package/src/model.rs
+++ b/catboost/rust-package/src/model.rs
@@ -149,7 +149,7 @@ impl Model {
 
         let mut text_features_ptr = text_features_ptr_storage
             .iter_mut()
-            .map(|object_texts_ptrs: &mut Vec<*const i8>| object_texts_ptrs.as_mut_ptr())
+            .map(|object_texts_ptrs: &mut Vec<*const core::ffi::c_char>| object_texts_ptrs.as_mut_ptr())
             .collect::<Vec<_>>();
 
         let mut embedding_dimensions = if !features.embedding_features.as_ref().is_empty() {


### PR DESCRIPTION
Fixes https://github.com/catboost/catboost/issues/2890