### PR TITLE
Update onnx_helpers.cpp to fix empty classlabels_strings bug

### DIFF
--- a/catboost/libs/model/model_export/onnx_helpers.cpp
+++ b/catboost/libs/model/model_export/onnx_helpers.cpp
@@ -230,9 +230,10 @@ static void AddClassLabelsAttribute(
 
     if (!classLabelsInt64.empty()) {
         AddAttribute("classlabels_int64s", classLabelsInt64, node);
-    } else {
+    } else if (!classLabelsString.empty()) {
         AddAttribute("classlabels_strings", classLabelsString, node);
     }
+    // If both vectors are empty (e.g., for regression models), no attribute is added.
 }
 
 static void InitProbabilitiesOutput(


### PR DESCRIPTION
There is currently an edge case when exporting a `CatBoostRegressor` trained with `RMSEWithUncertainty` to `ONNX`, we end up with empty classlabels_strings attributes that result in a broken model.
<img width="1125" height="672" alt="image" src="https://github.com/user-attachments/assets/3603a924-003d-4568-955b-4699157ff4cb" />

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
