### PR TITLE
Fix Linux build failures caused by missing standard library linking

### DIFF
--- a/cmake/global_flags.linker.gnu.cmake
+++ b/cmake/global_flags.linker.gnu.cmake
@@ -40,4 +40,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   # Android does not provide libpthread at all.
   # Once we will be building against glibc=2.34, we might simply remove -lpthread
   link_libraries(pthread)
+  
+  # Add standard C library and other essential libraries when using -nodefaultlibs
+  link_libraries(c m dl rt)
 endif()


### PR DESCRIPTION
CatBoost v1.2.8 build was failing with undefined symbol linker errors on Linux due to incomplete library linking configuration. The errors included:

- undefined symbol: fallocate64 (from glibc)
- undefined symbol: __isoc23_strtoll_l (from glibc locale functions)
- undefined symbol: pthread_getattr_np (from pthread extensions)
- undefined symbol: usleep (from POSIX standard library)
- undefined symbol: fchmod, sysinfo, flock (various system calls)

Root cause: The CMake configuration uses -nodefaultlibs to remove all default library linking, but only re-adds pthread. This strips out essential system libraries that contain the missing symbols.

Solution: Add essential system libraries back to the link configuration:
- libc (c): Standard C library containing most missing symbols
- libm (m): Math library for mathematical functions
- libdl (dl): Dynamic linker library for dlopen/dlsym
- librt (rt): POSIX realtime library for additional system functions

This change allows CatBoost v1.2.8 to build successfully on modern Linux systems while maintaining the intended custom library linking behavior.

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
