### PR TITLE
Automatically disable staged install on Mac arm64

### DIFF
--- a/.github/workflows/test_per_platform.yaml
+++ b/.github/workflows/test_per_platform.yaml
@@ -315,6 +315,6 @@ jobs:
         name: Check R package
         shell: pwsh
         run: |
-          Rscript -e "install.packages('remotes', Ncpus = parallel::detectCores()); remotes::install_local('catboost_R_package/catboost-R-darwin-universal2.tgz', INSTALL_opts = c('--no-multiarch', '--no-staged-install', '--install-tests'))"
+          Rscript -e "install.packages('remotes', Ncpus = parallel::detectCores()); remotes::install_local('catboost_R_package/catboost-R-darwin-universal2.tgz', INSTALL_opts = c('--no-multiarch', '--install-tests'))"
           Rscript -e "install.packages(c('testthat','caret','tibble'), Ncpus = parallel::detectCores()); testthat::test_package('catboost')"
 

--- a/catboost/R-package/configure
+++ b/catboost/R-package/configure
@@ -1738,12 +1738,16 @@ $as_echo "$R_PATH" >&6; }
 ##### Get CatBoost dyn lib #####################################################
 CATBOOST_FOUND=0
 OS_TYPE=$(uname)
+OS_ARCH=$(uname -m)
 
 # set dynlib suffix
 if [[ $OS_TYPE == 'Darwin' ]]; then
    DYNLIB_SUFFIX='dylib'
    echo "*** creating .so -> .dylib symlink for working with different R installations"
    ln -sf 'libcatboostr.dylib' 'src/libcatboostr.so'
+   if [[[ $OS_ARCH == 'arm64' ]]]; then
+      echo "StagedInstall: FALSE" >> DESCRIPTION
+   fi
 elif [[ $OS_TYPE == 'Linux' ]]; then
    DYNLIB_SUFFIX='so'
 else

--- a/catboost/R-package/configure.ac
+++ b/catboost/R-package/configure.ac
@@ -49,12 +49,16 @@ AC_MSG_RESULT($R_PATH)
 ##### Get CatBoost dyn lib #####################################################
 CATBOOST_FOUND=0
 OS_TYPE=$(uname)
+OS_ARCH=$(uname -m)
 
 # set dynlib suffix
 if [[[ $OS_TYPE == 'Darwin' ]]]; then
    DYNLIB_SUFFIX='dylib'
    echo "*** creating .so -> .dylib symlink for working with different R installations"
    ln -sf 'libcatboostr.dylib' 'src/libcatboostr.so'
+   if [[[ $OS_ARCH == 'arm64' ]]]; then
+      echo "StagedInstall: FALSE" >> DESCRIPTION
+   fi
 elif [[[ $OS_TYPE == 'Linux' ]]]; then
    DYNLIB_SUFFIX='so'
 else


### PR DESCRIPTION
Fixes #2491

Automatically sets the correct flags on MacOS such that users and build servers don't have special-case building of this package by setting `--no-staged-install`. See discussion at https://github.com/catboost/catboost/pull/2809 