### PR TITLE
Fix default loss inference for 2D labels

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1717,11 +1717,37 @@ def _get_loss_function_for_train(params, estimator_type, train_pool):
         if label is None:
             raise CatBoostError('loss function has not been specified and cannot be deduced')
 
+        label_arr = np.asarray(label)
+
+        if label_arr.ndim == 2:
+            if 1 in label_arr.shape:
+                label_arr = label_arr.reshape(-1)
+            else:
+                try:
+                    y = label_arr.astype(np.float64, copy=False)
+                except (TypeError, ValueError):
+                    raise CatBoostError("Can't infer loss for 2D label: non-numeric")
+
+                mn = y.min()
+                mx = y.max()
+                if not (np.isfinite(mn) and np.isfinite(mx)):
+                    raise CatBoostError("Can't infer loss for 2D label: NaN/inf")
+
+                if 0.0 <= mn and mx <= 1.0:
+                    if np.all((y == 0.0) | (y == 1.0)):
+                        return 'MultiLogloss'
+                    return 'MultiCrossEntropy'
+
+                raise CatBoostError("Can't infer loss for 2D label: values not in [0,1]")
+
+        elif label_arr.ndim > 2:
+            raise CatBoostError("Can't infer loss: label must be 1D or 2D")
+
         """
             len(set) is faster than np.unique on Python lists:
              https://bbengfort.github.io/observations/2017/05/02/python-unique-benchmark.html
         """
-        is_multiclass_task = len(set(label)) > 2 and 'target_border' not in params
+        is_multiclass_task = len(set(label_arr)) > 2 and 'target_border' not in params
         return 'MultiClass' if is_multiclass_task else 'Logloss'
     elif estimator_type == 'ranker':
         return 'YetiRank'

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1728,12 +1728,12 @@ def _get_loss_function_for_train(params, estimator_type, train_pool):
                 except (TypeError, ValueError):
                     raise CatBoostError("Can't infer loss for 2D label: non-numeric")
 
-                mn = y.min()
-                mx = y.max()
-                if not (np.isfinite(mn) and np.isfinite(mx)):
+                min_val = y.min()
+                max_val = y.max()
+                if not (np.isfinite(min_val) and np.isfinite(max_val)):
                     raise CatBoostError("Can't infer loss for 2D label: NaN/inf")
 
-                if 0.0 <= mn and mx <= 1.0:
+                if 0.0 <= min_val and max_val <= 1.0:
                     if np.all((y == 0.0) | (y == 1.0)):
                         return 'MultiLogloss'
                     return 'MultiCrossEntropy'

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -3159,6 +3159,50 @@ def test_multilabel_custom_objective(task_type, n=10):
         assert (abs(p1 - p2) < EPS).all()
 
 
+def test_default_loss_function_column_vector_label_no_crash():
+    rng = np.random.RandomState(0)
+    X = rng.rand(30, 5)
+    y = (rng.rand(30) > 0.5).astype(np.int32).reshape(-1, 1) 
+
+    model = CatBoostClassifier(iterations=2, depth=2, random_seed=0, verbose=False)
+    model.fit(X, y)
+
+    assert model.get_all_params()["loss_function"] == "Logloss"
+
+
+def test_default_loss_function_multilabel_binary_int_targets():
+    rng = np.random.RandomState(1)
+    X = rng.rand(30, 5)
+    y = (rng.rand(30, 3) > 0.5).astype(np.int32) 
+
+    model = CatBoostClassifier(iterations=2, depth=2, random_seed=0, verbose=False)
+    model.fit(X, y)
+
+    assert model.get_all_params()["loss_function"] == "MultiLogloss"
+
+
+def test_default_loss_function_multilabel_binary_float_targets():
+    rng = np.random.RandomState(2)
+    X = rng.rand(30, 5)
+    y = (rng.rand(30, 3) > 0.5).astype(np.float32) 
+
+    model = CatBoostClassifier(iterations=2, depth=2, random_seed=0, verbose=False)
+    model.fit(X, y)
+
+    assert model.get_all_params()["loss_function"] == "MultiLogloss"
+
+
+def test_default_loss_function_multilabel_soft_targets():
+    rng = np.random.RandomState(3)
+    X = rng.rand(30, 5)
+    y = rng.rand(30, 3).astype(np.float32)  
+
+    model = CatBoostClassifier(iterations=2, depth=2, random_seed=0, verbose=False)
+    model.fit(X, y)
+
+    assert model.get_all_params()["loss_function"] == "MultiCrossEntropy"
+
+
 def test_pool_after_fit(task_type):
     pool1 = Pool(TRAIN_FILE, column_description=CD_FILE)
     pool2 = Pool(TRAIN_FILE, column_description=CD_FILE)


### PR DESCRIPTION
Fixes a crash in default loss inference when training CatBoostClassifier with 2D labels. The update safely handles (n, 1) targets and adds default loss inference for true multilabel (n, k) targets, selecting `MultiLogloss` for binary labels and `MultiCrossEntropy` for soft labels. Includes regression tests.

Fixes #3020 
