### PR TITLE
Increase split threshold precision to 9 significant digits

### DIFF
--- a/catboost/private/libs/algo/tree_print.cpp
+++ b/catboost/private/libs/algo/tree_print.cpp
@@ -90,7 +90,7 @@ TString BuildDescription(const NCB::TFeaturesLayout& featuresLayout, const TFeat
             featuresLayout,
             feature.FloatFeature,
             EFeatureType::Float);
-        result << featureDescription << " border=" << feature.Split;
+        result << featureDescription << " border=" << FloatToString(feature.Split, PREC_POINT_DIGITS, 9);
     }
 
     for (const TOneHotSplit& feature : proj.OneHotFeatures) {
@@ -164,11 +164,11 @@ TString BuildDescription(const NCB::TFeaturesLayout& layout, const TModelSplit& 
     }
 
     if (feature.Type == ESplitType::OnlineCtr) {
-        result << ", border=" << feature.OnlineCtr.Border;
+        result << ", border=" << FloatToString(feature.OnlineCtr.Border, PREC_POINT_DIGITS, 9);
     } else if (feature.Type == ESplitType::FloatFeature) {
-        result << ", bin=" << feature.FloatFeature.Split;
+        result << ", bin=" << FloatToString(feature.FloatFeature.Split, PREC_POINT_DIGITS, 9);
     } else if (feature.Type == ESplitType::EstimatedFeature) {
-        result << ", bin=" << feature.EstimatedFeature.Split;
+        result << ", bin=" << FloatToString(feature.EstimatedFeature.Split, PREC_POINT_DIGITS, 9);
     } else {
         Y_ASSERT(feature.Type == ESplitType::OneHotFeature);
         result << ", value=";

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -3619,10 +3619,10 @@ class CatBoost(_CatBoostBase):
                 title='Bins',
                 tickmode='array',
                 tickvals=list(range(len(borders) + 1)),
-                ticktext=['(-inf, {:.4f}]'.format(borders[0])] +
-                         ['({:.4f}, {:.4f}]'.format(val_1, val_2)
+                ticktext=['(-inf, {:.9g}]'.format(borders[0])] +
+                         ['({:.9g}, {:.9g}]'.format(val_1, val_2)
                           for val_1, val_2 in zip(borders[:-1], borders[1:])] +
-                         ['({:.4f}, +inf)'.format(borders[-1])],
+                         ['({:.9g}, +inf)'.format(borders[-1])],
                 showticklabels=False
             )
 
@@ -3696,10 +3696,10 @@ class CatBoost(_CatBoostBase):
                 'title': 'Bins' if feature_name is None else 'Bins of feature \'{}\''.format(feature_name),
                 'tickmode': 'array',
                 'tickvals': list(range(len(borders) + 1)),
-                'ticktext': ['(-inf, {:.4f}]'.format(borders[0])] +
-                            ['({:.4f}, {:.4f}]'.format(val_1, val_2)
+                'ticktext': ['(-inf, {:.9g}]'.format(borders[0])] +
+                            ['({:.9g}, {:.9g}]'.format(val_1, val_2)
                              for val_1, val_2 in zip(borders[:-1], borders[1:])] +
-                            ['({:.4f}, +inf)'.format(borders[-1])],
+                            ['({:.9g}, +inf)'.format(borders[-1])],
                 'showticklabels': False}
 
         def plot2d(feature_names, borders, predictions):
@@ -7073,10 +7073,10 @@ def _build_binarized_feature_statistics_fig(statistics_list, pool_names):
             title='Bins',
             tickmode='array',
             tickvals=list(range(len(statistics['borders']) + 1)),
-            ticktext=['(-inf, {:.4f}]'.format(statistics['borders'][0])] +
-                     ['({:.4f}, {:.4f}]'.format(val_1, val_2)
+            ticktext=['(-inf, {:.9g}]'.format(statistics['borders'][0])] +
+                     ['({:.9g}, {:.9g}]'.format(val_1, val_2)
                       for val_1, val_2 in zip(statistics['borders'][:-1], statistics['borders'][1:])] +
-                     ['({:.4f}, +inf)'.format(statistics['borders'][-1])],
+                     ['({:.9g}, +inf)'.format(statistics['borders'][-1])],
             showticklabels=False
         )
     elif 'cat_values' in statistics.keys():


### PR DESCRIPTION
## Summary

Fixes #2415

Split thresholds in tree descriptions now use 9 significant digits, which guarantees lossless round-trip for 32-bit floats (IEEE 754 `FLT_DECIMAL_DIG = 9`). Previously, close-but-distinct splits could appear identical.

## Before

```
feature_0, bin=0.123457
feature_0, bin=0.123457    ← two different splits, same display
```

## After

```
feature_0, bin=0.123456015
feature_0, bin=0.123456992  ← now distinguishable
```

## Changes

### C++: `catboost/private/libs/algo/tree_print.cpp`

Used `FloatToString(..., PREC_POINT_DIGITS, 9)` (already available in the file for leaf values) for float split thresholds:

| Location | Field | Type |
|----------|-------|------|
| `BuildDescription(TModelSplit)` | `FloatFeature.Split` | `float` |
| `BuildDescription(TModelSplit)` | `OnlineCtr.Border` | `float` |
| `BuildDescription(TModelSplit)` | `EstimatedFeature.Split` | `float` |
| `BuildDescription(TFeatureCombination)` | `BinFeatures[i].Split` | `float` |

Integer fields (`BinBorder`, `SplitIdx`, `Value`) are left unchanged.

### Python: `catboost/python-package/catboost/core.py`

Replaced `{:.4f}` with `{:.9g}` in border formatting for:
- `plot_tree()` — tick labels for float feature splits (lines 3622-3625)
- `plot_tree()` — non-symmetric tree tick labels (lines 3699-3702)
- `calc_feature_statistics()` — border tick labels (lines 7076-7079)

Using `g` format strips trailing zeros so simple values like `0.5` don't become `0.500000000`.

## Why 9 digits?

IEEE 754 guarantees that 9 significant decimal digits are sufficient to uniquely represent any `float` (32-bit):

```
FLT_DECIMAL_DIG = 9  (from <float.h>)
```

The existing `FloatToString` with `PREC_POINT_DIGITS` is already used in the same file for leaf values (with precision 3), so this change is consistent with the codebase patterns.
