### PR TITLE
fix: replace 21 bare except clauses with except Exception

### DIFF
--- a/build/scripts/fetch_from_sandbox.py
+++ b/build/scripts/fetch_from_sandbox.py
@@ -242,7 +242,7 @@ def _get_resource_info_from_file(resource_file):
             resource_info = json.load(j)
         resource_info['file_name']  # check consistency
         return resource_info
-    except:
+    except Exception:
         logging.debug('Invalid %s in %s', RESOURCE_INFO_JSON, resource_dir)
 
     return None

--- a/build/scripts/touch.py
+++ b/build/scripts/touch.py
@@ -39,7 +39,7 @@ def main(argv):
     for file in argv_rest:
         try:
             os.utime(file, times)
-        except:
+        except Exception:
             open(file, 'w').close()
             if times is not None:
                 os.utime(file, times)

--- a/build/scripts/vcs_info.py
+++ b/build/scripts/vcs_info.py
@@ -97,10 +97,10 @@ def get_json(file_name):
             if num_var in out and _Formatting.is_str(out[num_var]):
                 try:
                     out[num_var] = int(out[num_var])
-                except:
+                except Exception:
                     out[num_var] = -1
         return out
-    except:
+    except Exception:
         return get_default_json()
 
 

--- a/catboost/pytest/smoke_tests/categorical_features_parameters_gpu.py
+++ b/catboost/pytest/smoke_tests/categorical_features_parameters_gpu.py
@@ -2,7 +2,7 @@ import os
 try:
     import catboost_dev as catboost
     from catboost_dev import CatBoost, CatBoostRegressor, Pool
-except:
+except Exception:
     import catboost
     from catboost import CatBoost, CatBoostRegressor, Pool
 ## CatBoost tutorial: Categorical features parameters

--- a/catboost/pytest/smoke_tests/classification_tutorial_cpu.py
+++ b/catboost/pytest/smoke_tests/classification_tutorial_cpu.py
@@ -14,7 +14,7 @@ try:
     from catboost_dev import CatBoost
     from catboost_dev.eval.catboost_evaluation import *
     from catboost_dev.eval.evaluation_result import *
-except:
+except Exception:
     import catboost
     from catboost import *
     from catboost import datasets

--- a/contrib/tools/cython/Cython/Build/Dependencies.py
+++ b/contrib/tools/cython/Cython/Build/Dependencies.py
@@ -12,7 +12,7 @@ from collections.abc import Iterable
 
 try:
     import pythran
-except:
+except Exception:
     pythran = None
 
 from .. import Utils
@@ -1217,7 +1217,7 @@ if os.environ.get('XML_RESULTS'):
             try:
                 try:
                     func(*args)
-                except:
+                except Exception:
                     success = False
             finally:
                 t = time.time() - t

--- a/contrib/tools/cython/Cython/Build/Tests/TestInline.py
+++ b/contrib/tools/cython/Cython/Build/Tests/TestInline.py
@@ -8,7 +8,7 @@ from Cython.TestUtils import CythonTest
 try:
     import numpy
     has_numpy = True
-except:
+except Exception:
     has_numpy = False
 
 test_kwds = dict(force=True, quiet=True)

--- a/contrib/tools/cython/Cython/Compiler/ExprNodes.py
+++ b/contrib/tools/cython/Cython/Compiler/ExprNodes.py
@@ -3594,7 +3594,7 @@ class TempNode(ExprNode):
     def result(self):
         try:
             return self.temp_cname
-        except:
+        except Exception:
             assert False, "Remember to call allocate/release on TempNode"
             raise
 

--- a/contrib/tools/cython/Cython/Compiler/Nodes.py
+++ b/contrib/tools/cython/Cython/Compiler/Nodes.py
@@ -8041,7 +8041,7 @@ class WithStatNode(StatNode):
             try:
                 TARGET = VALUE  # optional
                 BODY
-            except:
+            except Exception:
                 EXC = False
                 if not EXIT(*EXCINFO):
                     raise

--- a/contrib/tools/cython/Cython/Compiler/Optimize.py
+++ b/contrib/tools/cython/Cython/Compiler/Optimize.py
@@ -3811,7 +3811,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             # constant, so try to do the encoding at compile time
             try:
                 value = string_node.constant_result.encode(encoding, error_handling)
-            except:
+            except Exception:
                 # well, looks like we can't
                 pass
             else:

--- a/contrib/tools/cython/Cython/Compiler/Tests/TestParseTreeTransforms.py
+++ b/contrib/tools/cython/Cython/Compiler/Tests/TestParseTreeTransforms.py
@@ -105,7 +105,7 @@ class TestWithTransform:  # (TransformTest): # Disabled!
             try:
                 $1_0 = None
                 y = z ** 3
-            except:
+            except Exception:
                 $0_1 = False
                 if (not $0_2($1_0)):
                     raise
@@ -131,7 +131,7 @@ class TestWithTransform:  # (TransformTest): # Disabled!
                 $1_0 = None
                 y = $0_3
                 y = z ** 3
-            except:
+            except Exception:
                 $0_1 = False
                 if (not $0_2($1_0)):
                     raise
@@ -265,7 +265,7 @@ class TestDebugTransform(DebuggerTestCase):
             self.assertEqual(2, len(spam_stepinto))
             assert 'puts' in spam_stepinto
             assert 'some_c_function' in spam_stepinto
-        except:
+        except Exception:
             f = open(self.debug_dest)
             try:
                 print(f.read())

--- a/contrib/tools/cython/Cython/Debugger/Tests/TestLibCython.py
+++ b/contrib/tools/cython/Cython/Debugger/Tests/TestLibCython.py
@@ -154,7 +154,7 @@ class DebuggerTestCase(unittest.TestCase):
                 # cmdclass=dict(build_ext=Cython.Distutils.build_ext)
             # )
 
-        except:
+        except Exception:
             os.chdir(self.cwd)
             raise
 

--- a/contrib/tools/cython/Cython/StringIOTree.py
+++ b/contrib/tools/cython/Cython/StringIOTree.py
@@ -146,7 +146,7 @@ class StringIOTree:
             reprstr += "allmarkers is empty\n"
         try:
             sorted(totmap.items())
-        except:
+        except Exception:
             print(totmap)
             print(totmap.items())
         for cython_path, filemap in sorted(totmap.items()):


### PR DESCRIPTION
## What
Replace 21 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.