### PR TITLE
Fix feature name parser misreading hyphens as range operators

### DIFF
--- a/catboost/libs/data/feature_names_converter.h
+++ b/catboost/libs/data/feature_names_converter.h
@@ -67,9 +67,14 @@ namespace {
                 CB_ENSURE(tagIndices, TStringBuf() << "There is no tag '#" << tag << "' in pool metainfo");
                 indices->insert(indices->end(), tagIndices->begin(), tagIndices->end());
             } else {
+                if (IndicesFromNames.contains(str)) {
+                    indices->push_back(IndicesFromNames.at(str));
+                    return;
+                }
                 auto left = str;
                 auto right = str;
-                StringSplitter(str).Split('-').TryCollectInto(&left, &right);
+                const bool isRange = StringSplitter(str).Split('-').TryCollectInto(&left, &right);
+                CB_ENSURE(isRange, "String '" + str + "' is not a feature name");
                 for (ui32 idx : xrange(ConvertToIndex(left, IndicesFromNames), ConvertToIndex(right, IndicesFromNames) + 1)) {
                     indices->push_back(idx);
                 }

--- a/catboost/libs/data/feature_names_converter.h
+++ b/catboost/libs/data/feature_names_converter.h
@@ -77,7 +77,7 @@ namespace {
                 auto left = str;
                 auto right = str;
                 const bool isRange = StringSplitter(str).Split('-').TryCollectInto(&left, &right);
-                CB_ENSURE(isRange, "String '" + str + "' is not a feature name");
+                CB_ENSURE(isRange, "String '" + str + "' does not represent a valid feature index, name or a feature range");
                 for (ui32 idx : xrange(ConvertToIndex(left, IndicesFromNames), ConvertToIndex(right, IndicesFromNames) + 1)) {
                     indices->push_back(idx);
                 }

--- a/catboost/libs/data/feature_names_converter.h
+++ b/catboost/libs/data/feature_names_converter.h
@@ -67,9 +67,12 @@ namespace {
                 CB_ENSURE(tagIndices, TStringBuf() << "There is no tag '#" << tag << "' in pool metainfo");
                 indices->insert(indices->end(), tagIndices->begin(), tagIndices->end());
             } else {
-                if (IndicesFromNames.contains(str)) {
-                    indices->push_back(IndicesFromNames.at(str));
-                    return;
+                {
+                    auto it = IndicesFromNames.find(str);
+                    if (it != IndicesFromNames.end()) {
+                        indices->push_back(it->second);
+                        return;
+                    }
                 }
                 auto left = str;
                 auto right = str;

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -10934,6 +10934,30 @@ def test_select_features_by_multi_feature_tags(task_type, train_final_model, alg
     return local_canonical_file(summary_file_name, diff_tool=get_limited_precision_json_diff_tool(1.e-6))
 
 
+def test_select_features_with_hyphenated_feature_names():
+    features, labels = generate_random_labeled_dataset(
+        n_samples=500,
+        n_features=4,
+        labels=[0, 1],
+        seed=42
+    )
+    feature_names = ['non-TB', 'feat-b', 'plain', 'other-feat']
+    learn = Pool(features, labels, feature_names=feature_names)
+    test = Pool(features, labels, feature_names=feature_names)
+    model = CatBoostClassifier(iterations=10, logging_level='Silent')
+    summary = model.select_features(
+        learn,
+        eval_set=test,
+        steps=1,
+        train_final_model=False,
+        features_for_select=['non-TB', 'feat-b'],
+        num_features_to_select=1
+    )
+    assert len(summary['selected_features']) == 1
+    assert len(summary['eliminated_features']) == 1
+    assert set(summary['selected_features_names'] + summary['eliminated_features_names']) == {'non-TB', 'feat-b'}
+
+
 def test_embedding_features_data_list_with_data_with_features_order():
     pool1 = Pool(
         data=pd.DataFrame(


### PR DESCRIPTION
Feature names containing hyphens caused a crash in `select_features()` because `TIndicesMapper::Map()` unconditionally split any string that was not a numeric index or `#tag` on `'-'` to parse it as an index range, and the return value of
`TryCollectInto` was not captured. A name like `"non-TB"` splits into exactly two tokens, so the code erroneously attempted a range lookup on the two halves, producing a confusing error that named part of the original feature name as the culprit.

I added an exact `IndicesFromNames` lookup before the range parsing path, so hyphenated names are resolved without ever reaching the range logic. I also now capture `TryCollectInto`'s return value and assert it with `CB_ENSURE`, so
strings that are neither a known feature name nor a valid range produce a clear error instead of silently misinterpreting partial tokens. Added a regression test.

Fixes #2983