### PR TITLE
Addition of Piecewise Quantile Loss

### DIFF
--- a/catboost/libs/helpers/quantile.cpp
+++ b/catboost/libs/helpers/quantile.cpp
@@ -1,5 +1,7 @@
 #include "quantile.h"
 
+#include <catboost/private/libs/algo_helpers/quantile_selection.h>
+
 #include <util/generic/algorithm.h>
 #include <util/generic/array_ref.h>
 #include <util/generic/vector.h>
@@ -7,6 +9,7 @@
 #include <util/generic/ymath.h>
 
 #include <algorithm>
+#include <cmath>
 
 namespace {
     struct TValueWithWeight {
@@ -123,4 +126,92 @@ double CalcSampleQuantile(
     return sampleRef.size() < 100
         ? CalcSampleQuantileLinearSearch(sampleRef, weightsRef, alpha)
         : CalcSampleQuantileBinarySearch(sampleRef, weightsRef, alpha);
+}
+
+static double CalcPiecewiseQuantileMinimumBinarySearch(
+    TConstArrayRef<float> sampleRef,
+    TConstArrayRef<float> weightsRef,
+    TConstArrayRef<float> origTarget,
+    TConstArrayRef<double> boundaries,
+    TConstArrayRef<double> quantiles)
+{
+    constexpr int BINARY_SEARCH_ITERATIONS = 100;
+    const size_t sampleSize = sampleRef.size();
+
+    TVector<TValueWithWeight> elements;
+    TVector<TValueWithWeight> origs;
+    elements.yresize(sampleSize);
+    origs.yresize(sampleSize);
+    for (auto i : xrange(sampleSize))
+    {
+        elements[i] = {sampleRef[i], weightsRef[i]};
+        origs[i] = {sampleRef[i], origTarget[i]};
+    }
+    Sort(elements, [](const TValueWithWeight &elem1, const TValueWithWeight &elem2)
+         { return elem1.Value < elem2.Value; });
+    Sort(origs, [](const TValueWithWeight &elem1, const TValueWithWeight &elem2)
+         { return elem1.Value < elem2.Value; });
+
+    TVector<double> leftDer;
+    TVector<double> rightDer;
+    leftDer.yresize(sampleSize);
+    rightDer.yresize(sampleSize);
+    for (auto i : xrange(sampleSize))
+    {
+        double a = select_quantile(boundaries, quantiles, origs[i].Weight);
+        leftDer[i] = -a * elements[i].Weight;
+        rightDer[i] = (1.0 - a) * elements[i].Weight;
+    }
+    TVector<double> leftDerAccum;
+    TVector<double> rightDerAccum;
+    leftDerAccum.yresize(sampleSize);
+    rightDerAccum.yresize(sampleSize);
+    leftDerAccum[sampleSize - 1] = 0;
+    rightDerAccum[0] = 0;
+    for (auto i : xrange(size_t(1), sampleSize))
+    {
+        leftDerAccum[sampleSize - 1 - i] = leftDerAccum[sampleSize - i] + leftDer[sampleSize - i];
+        rightDerAccum[i] = rightDer[i-1] + rightDerAccum[i - 1];
+    }
+    size_t l = 0;
+    size_t r = sampleSize - 1;
+    size_t n = 0;
+    for (auto it : xrange(BINARY_SEARCH_ITERATIONS))
+    {
+        Y_UNUSED(it);
+        if (r - l == 1)
+        {
+            n = fabs(rightDerAccum[l] + leftDerAccum[l]) < fabs(rightDerAccum[r] + leftDerAccum[r]) ? l : r;
+            break;
+        }
+        n = l + ceil((r - l) / 2.);
+        if ((n == r) || (fabs(rightDerAccum[n] + leftDerAccum[n]) < 1.e-9))
+            break;
+        if ((rightDerAccum[n] + leftDerAccum[n]) * (rightDerAccum[l] + leftDerAccum[l]) < 0)
+            r = n;
+        else
+            l = n;
+    }
+    return elements[n].Value;
+}
+
+double CalcPiecewiseQuantileMinimum(
+    TConstArrayRef<float> sampleRef,
+    TConstArrayRef<float> weightsRef,
+    TConstArrayRef<float> origTarget,
+    TConstArrayRef<double> boundaries,
+    TConstArrayRef<double> quantiles)
+{
+    if (sampleRef.empty())
+    {
+        return 0.0;
+    }
+    TVector<float> defaultWeights;
+    if (weightsRef.empty())
+    {
+        defaultWeights.resize(sampleRef.size(), 1.0);
+        weightsRef = defaultWeights;
+    }
+    Y_ASSERT(sampleRef.size() == weightsRef.size());
+    return CalcPiecewiseQuantileMinimumBinarySearch(sampleRef, weightsRef, origTarget, boundaries, quantiles);
 }

--- a/catboost/libs/helpers/quantile.h
+++ b/catboost/libs/helpers/quantile.h
@@ -10,3 +10,13 @@ double CalcSampleQuantile(
     TConstArrayRef<float> weights,
     double alpha
 );
+
+// Finds the optimum of the piecewise quantile loss function through binary search.
+// boundaries: N-1 sorted boundary values; quantiles: N quantile levels.
+double CalcPiecewiseQuantileMinimum(
+    TConstArrayRef<float> sampleRef,
+    TConstArrayRef<float> weightsRef,
+    TConstArrayRef<float> origTarget,
+    TConstArrayRef<double> boundaries,
+    TConstArrayRef<double> quantiles
+);

--- a/catboost/libs/metrics/metric.cpp
+++ b/catboost/libs/metrics/metric.cpp
@@ -19,6 +19,7 @@
 #include <catboost/libs/helpers/math_utils.h>
 #include <catboost/libs/helpers/short_vector_ops.h>
 #include <catboost/libs/helpers/vector_helpers.h>
+#include <catboost/private/libs/algo_helpers/quantile_selection.h>
 #include <catboost/libs/eval_result/eval_helpers.h>
 #include <catboost/libs/logging/logging.h>
 #include <catboost/private/libs/options/enum_helpers.h>
@@ -1035,6 +1036,141 @@ void TLqMetric::GetBestValue(EMetricBestValue* valueType, float* bestValue) cons
     if (bestValue) {
         *bestValue = 0;
     }
+}
+
+/* PiecewiseQuantile */
+
+namespace
+{
+    class TPiecewiseQuantileMetric final : public TAdditiveSingleTargetMetric
+    {
+    public:
+        explicit TPiecewiseQuantileMetric(ELossFunction lossFunction,
+                                                const TLossParams &params,
+                                                TVector<double> boundaries,
+                                                TVector<double> quantiles,
+                                                double delta);
+
+        static TVector<THolder<IMetric>> Create(const TMetricConfig &config);
+        static TVector<TParamSet> ValidParamSets();
+
+        TMetricHolder EvalSingleThread(
+            TConstArrayRef<TConstArrayRef<double>> approx,
+            TConstArrayRef<TConstArrayRef<double>> approxDelta,
+            bool isExpApprox,
+            TConstArrayRef<float> target,
+            TConstArrayRef<float> weight,
+            TConstArrayRef<TQueryInfo> queriesInfo,
+            int begin,
+            int end) const override;
+        TString GetDescription() const override;
+        void GetBestValue(EMetricBestValue *valueType, float *bestValue) const override;
+
+    private:
+        TVector<double> Boundaries;
+        TVector<double> Quantiles;
+        double Delta;
+    };
+}
+
+// static.
+TVector<THolder<IMetric>> TPiecewiseQuantileMetric::Create(const TMetricConfig &config)
+{
+    CB_ENSURE(config.Metric == ELossFunction::PiecewiseQuantile, "Unreachable.");
+
+    const auto& lossParams = config.GetParamsMap();
+    auto boundaries = NCatboostOptions::GetBoundariesPiecewiseQuantile(lossParams);
+    auto quantiles = NCatboostOptions::GetQuantilesPiecewiseQuantile(lossParams);
+    CB_ENSURE(quantiles.size() == boundaries.size() + 1,
+        "quantiles count (" << quantiles.size() << ") must equal boundaries count + 1 (" << boundaries.size() + 1 << ")");
+    double delta = NCatboostOptions::GetParamOrDefault(lossParams, "delta", 1e-6);
+
+    config.ValidParams->insert("boundaries");
+    config.ValidParams->insert("quantiles");
+    config.ValidParams->insert("delta");
+    return AsVector(MakeHolder<TPiecewiseQuantileMetric>(
+        config.Metric, config.Params, std::move(boundaries), std::move(quantiles), delta));
+}
+
+TPiecewiseQuantileMetric::TPiecewiseQuantileMetric(
+    ELossFunction lossFunction, const TLossParams &params,
+    TVector<double> boundaries, TVector<double> quantiles, double delta)
+    : TAdditiveSingleTargetMetric(lossFunction, params)
+    , Boundaries(std::move(boundaries))
+    , Quantiles(std::move(quantiles))
+    , Delta(delta)
+{
+    Y_ASSERT(lossFunction == ELossFunction::PiecewiseQuantile);
+    CB_ENSURE(Quantiles.size() == Boundaries.size() + 1,
+        "quantiles count must equal boundaries count + 1");
+    for (size_t i = 1; i < Boundaries.size(); ++i) {
+        CB_ENSURE(Boundaries[i - 1] < Boundaries[i], "Boundaries must be in ascending order");
+    }
+    CB_ENSURE(AllOf(Quantiles, [] (double q) { return q > -1e-6 && q < 1.0 + 1e-6; }),
+        "Quantiles should be in interval [0, 1]");
+}
+
+TMetricHolder TPiecewiseQuantileMetric::EvalSingleThread(
+    TConstArrayRef<TConstArrayRef<double>> approx,
+    TConstArrayRef<TConstArrayRef<double>> approxDelta,
+    bool isExpApprox,
+    TConstArrayRef<float> target,
+    TConstArrayRef<float> weight,
+    TConstArrayRef<TQueryInfo> /*queriesInfo*/,
+    int begin,
+    int end) const
+{
+    CB_ENSURE(approx.size() == 1, "Metric quantile supports only single-dimensional data");
+    Y_ASSERT(!isExpApprox);
+    const auto impl = [=, this](auto hasDelta, auto hasWeight) {
+        TConstArrayRef<double> approxVec = approx[0];
+        TConstArrayRef<double> approxDeltaVec = GetRowRef(approxDelta, /*rowIdx*/ 0);
+        TMetricHolder error(2);
+        for (int i : xrange(begin, end)) {
+            double val = target[i] - approxVec[i];
+            if (hasDelta) {
+                val -= approxDeltaVec[i];
+            }
+            const double alpha = select_quantile(Boundaries, Quantiles, target[i]);
+            const double multiplier = (abs(val) < Delta) ? 0 : ((val > 0) ? alpha : -(1 - alpha));
+            if (val < -Delta) {
+                val += Delta;
+            } else if (val > Delta) {
+                val -= Delta;
+            }
+            const float w = hasWeight ? weight[i] : 1;
+            error.Stats[0] += (multiplier * val) * w;
+            error.Stats[1] += w;
+        }
+        return error;
+    };
+    return DispatchGenericLambda(impl, !approxDelta.empty(), !weight.empty());
+}
+
+TString TPiecewiseQuantileMetric::GetDescription() const
+{
+    const TMetricParam<TVector<double>> boundaries("boundaries", Boundaries, /*userDefined*/ true);
+    const TMetricParam<TVector<double>> quantiles("quantiles", Quantiles, /*userDefined*/ true);
+    if (Delta == 1e-6) {
+        return BuildDescription(ELossFunction::PiecewiseQuantile, UseWeights, "%.3g", boundaries, "%.3g", quantiles);
+    }
+    const TMetricParam<double> delta("delta", Delta, /*userDefined*/ true);
+    return BuildDescription(ELossFunction::PiecewiseQuantile, UseWeights, "%.3g", boundaries, "%.3g", quantiles, "%g", delta);
+}
+void TPiecewiseQuantileMetric::GetBestValue(EMetricBestValue *valueType, float *) const
+{
+    *valueType = EMetricBestValue::Min;
+}
+
+TVector<TParamSet> TPiecewiseQuantileMetric::ValidParamSets()
+{
+    return {
+        TParamSet{
+            {TParamInfo{"use_weights", false, true},
+             TParamInfo{"boundaries", false, TString("0")},
+             TParamInfo{"quantiles", false, TString("1,0.5")},
+             TParamInfo{"delta", false, 1e-6}},
+            ""}};
 }
 
 /* Quantile */
@@ -6369,6 +6505,9 @@ TVector<THolder<IMetric>> CreateMetric(ELossFunction metric, const TLossParams& 
         case ELossFunction::Quantile:
             AppendTemporaryMetricsVector(TQuantileMetric::Create(config), &result);
             break;
+        case ELossFunction::PiecewiseQuantile:
+            AppendTemporaryMetricsVector(TPiecewiseQuantileMetric::Create(config), &result);
+            break;
         case ELossFunction::MultiQuantile:
             AppendTemporaryMetricsVector(TMultiQuantileMetric::Create(config), &result);
             break;
@@ -6629,6 +6768,8 @@ TVector<TParamSet> ValidParamSets(ELossFunction metric) {
         case ELossFunction::MAE:
         case ELossFunction::Quantile:
             return TQuantileMetric::ValidParamSets();
+        case ELossFunction::PiecewiseQuantile:
+            return TPiecewiseQuantileMetric::ValidParamSets();
         case ELossFunction::MultiQuantile:
             return TMultiQuantileMetric::ValidParamSets();
         case ELossFunction::Expectile:
@@ -7051,7 +7192,7 @@ bool IsMinOptimal(TStringBuf lossFunction) {
 }
 
 bool IsQuantileLoss(const ELossFunction& loss) {
-    return loss == ELossFunction::Quantile || loss == ELossFunction::MultiQuantile || loss == ELossFunction::MAE;
+    return loss == ELossFunction::Quantile || loss == ELossFunction::PiecewiseQuantile || loss == ELossFunction::MultiQuantile || loss == ELossFunction::MAE;
 }
 
 namespace NCB {

--- a/catboost/libs/metrics/optimal_const_for_loss.h
+++ b/catboost/libs/metrics/optimal_const_for_loss.h
@@ -180,7 +180,8 @@ namespace NCB {
     inline TMaybe<double> CalcOneDimensionalOptimumConstApprox(
         const NCatboostOptions::TLossDescription& lossDescription,
         TConstArrayRef<float> target,
-        TConstArrayRef<float> weights
+        TConstArrayRef<float> weights,
+        TConstArrayRef<float> origTarget = TConstArrayRef<float>()
     ) {
         // TODO(ilyzhin): refactor it (https://a.yandex-team.ru/review/969134/details#comment-1471301)
         auto lossFunction = lossDescription.GetLossFunction();
@@ -192,6 +193,16 @@ namespace NCB {
             {
                 const double bestProbability = CalculateWeightedTargetAverage(target, weights);
                 return Logit(bestProbability);
+            }
+            case ELossFunction::PiecewiseQuantile:
+            {
+                const auto& params = lossDescription.GetLossParamsMap();
+                auto boundaries = NCatboostOptions::GetBoundariesPiecewiseQuantile(params);
+                auto quantiles = NCatboostOptions::GetQuantilesPiecewiseQuantile(params);
+                const TVector<float> defaultWeights(target.size(), 1);
+                const auto weightsRef = weights.empty() ? MakeConstArrayRef(defaultWeights) : weights;
+                const auto origTargetRef = origTarget.empty() ? MakeConstArrayRef(target) : origTarget;
+                return CalcPiecewiseQuantileMinimum(target, weightsRef, origTargetRef, boundaries, quantiles);
             }
             case ELossFunction::Quantile:
             case ELossFunction::GroupQuantile:

--- a/catboost/libs/metrics/ut/CMakeLists.darwin-arm64.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.darwin-arm64.txt
@@ -64,6 +64,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.darwin-x86_64.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.darwin-x86_64.txt
@@ -65,6 +65,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.linux-aarch64-cuda.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.linux-aarch64-cuda.txt
@@ -68,6 +68,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.linux-aarch64.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.linux-aarch64.txt
@@ -67,6 +67,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.linux-ppc64le-cuda.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.linux-ppc64le-cuda.txt
@@ -68,6 +68,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.linux-ppc64le.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.linux-ppc64le.txt
@@ -67,6 +67,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.linux-x86_64-cuda.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.linux-x86_64-cuda.txt
@@ -70,6 +70,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.linux-x86_64.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.linux-x86_64.txt
@@ -69,6 +69,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.windows-x86_64-cuda.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.windows-x86_64-cuda.txt
@@ -57,6 +57,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/CMakeLists.windows-x86_64.txt
+++ b/catboost/libs/metrics/ut/CMakeLists.windows-x86_64.txt
@@ -57,6 +57,8 @@ target_sources(catboost-libs-metrics-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/total_f1_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/tweedie_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/pr_auc_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
 )
 
 

--- a/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
+++ b/catboost/libs/metrics/ut/piecewise_quantile_metric_ut.cpp
@@ -1,0 +1,76 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <catboost/libs/metrics/metric.h>
+
+Y_UNIT_TEST_SUITE(TPiecewiseQuantileMetricTest) {
+
+    double q1 = 0.2;
+    double q2 = 0.5;
+    double q3 = 0.8;
+
+    TVector<float> targets={1.,1.,3.,6.,7.,11.,12.};
+    TVector<TVector<double>> approxes={{1.,3.,1.,7.,6.,12.,11.}};
+    TVector<float> weights={1.,2.,3.,4.,5.,6.,7.};
+
+    TVector<TString> loss_description = {"PiecewiseQuantile:boundaries=5,10;quantiles=0.2,0.5,0.8"};
+    ui32 docCount = SafeIntegerCast<ui32>(targets.size());
+    TVector<TQueryInfo> queryInfos;
+
+    //integration test
+    Y_UNIT_TEST(PiecewiseQuantileMetric1) {
+        auto metric = CreateMetricsFromDescription(loss_description,1);
+        NPar::TLocalExecutor localexec;
+        auto result = dynamic_cast<TSingleTargetMetric*>(metric[0].Get())->Eval(approxes, targets, weights, queryInfos, 0, 1, localexec);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.Stats[0],0.,5e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileMetric2) {
+        auto metric = CreateMetricsFromDescription(loss_description,1);
+        NPar::TLocalExecutor localexec;
+        auto result = dynamic_cast<TSingleTargetMetric*>(metric[0].Get())->Eval(approxes, targets, weights, queryInfos, 1, 2, localexec);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.Stats[0],-(targets[1]-approxes[0][1])*(1-q1)*weights[1],5e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileMetric3) {
+        auto metric = CreateMetricsFromDescription(loss_description,1);
+        NPar::TLocalExecutor localexec;
+        auto result = dynamic_cast<TSingleTargetMetric*>(metric[0].Get())->Eval(approxes, targets, weights, queryInfos, 2, 3, localexec);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.Stats[0],(targets[2]-approxes[0][2])*q1*weights[2],5e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileMetric4) {
+        auto metric = CreateMetricsFromDescription(loss_description,1);
+        NPar::TLocalExecutor localexec;
+        auto result = dynamic_cast<TSingleTargetMetric*>(metric[0].Get())->Eval(approxes, targets, weights, queryInfos, 3, 4, localexec);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.Stats[0],-(targets[3]-approxes[0][3])*(1-q2)*weights[3],5e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileMetric5) {
+        auto metric = CreateMetricsFromDescription(loss_description,1);
+        NPar::TLocalExecutor localexec;
+        auto result = dynamic_cast<TSingleTargetMetric*>(metric[0].Get())->Eval(approxes, targets, weights, queryInfos, 4, 5, localexec);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.Stats[0],(targets[4]-approxes[0][4])*q2*weights[4],5e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileMetric6) {
+        auto metric = CreateMetricsFromDescription(loss_description,1);
+        NPar::TLocalExecutor localexec;
+        auto result = dynamic_cast<TSingleTargetMetric*>(metric[0].Get())->Eval(approxes, targets, weights, queryInfos, 5, 6, localexec);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.Stats[0],-(targets[5]-approxes[0][5])*(1-q3)*weights[5],5e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileMetric7) {
+        auto metric = CreateMetricsFromDescription(loss_description,1);
+        NPar::TLocalExecutor localexec;
+        auto result = dynamic_cast<TSingleTargetMetric*>(metric[0].Get())->Eval(approxes, targets, weights, queryInfos, 6, 7, localexec);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.Stats[0],(targets[4]-approxes[0][4])*q3*weights[6],1e-5);
+    }
+
+    //check that it all works together
+    Y_UNIT_TEST(PiecewiseQuantileMetricAll) {
+        auto metric = CreateMetricsFromDescription(loss_description,1);
+        NPar::TLocalExecutor localexec;
+        auto result = dynamic_cast<TSingleTargetMetric*>(metric[0].Get())->Eval(approxes, targets, weights, queryInfos, 1, docCount, localexec);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.Stats[0],-(targets[1]-approxes[0][1])*(1-q1)*weights[1]
+                                                  +(targets[2]-approxes[0][2])*(q1)*weights[2]
+                                                  -(targets[3]-approxes[0][3])*(1-q2)*weights[3]
+                                                  +(targets[4]-approxes[0][4])*(q2)*weights[4]
+                                                  -(targets[5]-approxes[0][5])*(1-q3)*weights[5]
+                                                  +(targets[6]-approxes[0][6])*(q3)*weights[6]
+        ,1e-4);
+    }
+
+}

--- a/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
+++ b/catboost/libs/metrics/ut/piecewise_quantile_ut.cpp
@@ -1,0 +1,125 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <catboost/libs/metrics/optimal_const_for_loss.h>
+#include <catboost/private/libs/options/restrictions.h>
+
+#include <util/generic/array_ref.h>
+#include <util/generic/fwd.h>
+#include <util/generic/vector.h>
+
+#include <cfloat>
+
+using namespace NCB;
+
+Y_UNIT_TEST_SUITE(TCalculateWeightedPiecewiseQuantile) {
+
+    const TVector<float> weightsNoWeights = {1, 1, 1, 1, 1};
+    const TVector<float> weightsHasWeights = {0.1, 0.1, 0.5, 0.5, 0.8};
+    const TVector<float> sampleOrderedNoWeights = {1, 2, 3, 4, 5};
+    const TVector<float> sampleUnorderedNoWeights = {2, 1, 5, 3, 4};
+    const TVector<float> diffs = {0.1, 0.2, 0.3, 0.4, 0.5};
+    const TVector<float> diffsUnordered = {0.2, 0.1, 0.5, 0.3, 0.4};
+
+
+    // no weights, original and new sample are the same, everything is ordered.
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsLowBound) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleOrderedNoWeights, weightsNoWeights, sampleOrderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.01, 0.01, 0.01}), 1, 1e-6);
+    }
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsHighBound) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleOrderedNoWeights, weightsNoWeights, sampleOrderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{1.0, 1.0, 1.0}), 5 , 1e-6);
+    }
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsMid) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleOrderedNoWeights, weightsNoWeights, sampleOrderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.5, 0.5, 0.5}), 3 , 1e-6);
+    }
+
+    // no weights, original and new sample are the same, check that ordering works
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDisorderedLowBound) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleUnorderedNoWeights, weightsNoWeights, sampleUnorderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.01, 0.01, 0.01}), 1, 1e-6);
+    }
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDisorderedHighBound) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleUnorderedNoWeights, weightsNoWeights, sampleOrderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{1.0, 1.0, 1.0}), 5 , 1e-6);
+    }
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDisorderedMid) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleUnorderedNoWeights, weightsNoWeights, sampleUnorderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.5, 0.5, 0.5}), 3 , 1e-6);
+    }
+
+    // no weights, original and new sample differ, everything is ordered
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDiffLowBound) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(diffs, weightsNoWeights, sampleOrderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.01, 0.01, 0.01}), 0.1, 1e-6);
+    }
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDiffHighBound) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(diffs, weightsNoWeights, sampleOrderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{1.0, 1.0, 1.0}), 0.5 , 1e-6);
+    }
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDiffMid) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(diffs, weightsNoWeights, sampleOrderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.5, 0.5, 0.5}), 0.3 , 1e-6);
+    }
+
+    // no weights, original and new sample differ, but things aren't ordered any more (checks that both arrays are sorted together)
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDiffDisorderedLowBound) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(diffsUnordered, weightsNoWeights, sampleUnorderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.01, 0.01, 0.01}), 0.1, 1e-6);
+    }
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDiffDisorderedHighBound) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(diffsUnordered, weightsNoWeights, sampleUnorderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{1.0, 1.0, 1.0}), 0.5 , 1e-6);
+    }
+
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualNoWeightsDiffDisorderedMid) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(diffsUnordered, weightsNoWeights, sampleUnorderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.5, 0.5, 0.5}), 0.3 , 1e-6);
+    }
+
+
+    // test multiple quantiles individually in for each window
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumMultifirstWindow) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleOrderedNoWeights, weightsNoWeights, sampleOrderedNoWeights,
+        TVector<double>{10, 20}, TVector<double>{0.5, 0.1, 0.1}), 3 , 1e-6);
+    }
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumMultisecondWindow) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleOrderedNoWeights, weightsNoWeights, sampleOrderedNoWeights,
+        TVector<double>{0.1, 10}, TVector<double>{0.1, 0.5, 0.1}), 3 , 1e-6);
+    }
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumMultithirdWindow) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleOrderedNoWeights, weightsNoWeights, sampleOrderedNoWeights,
+        TVector<double>{0.1, 0.2}, TVector<double>{0.1, 0.1, 0.5}), 3 , 1e-6);
+    }
+
+    // test simple case, but with weights
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualWeights) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleOrderedNoWeights, weightsHasWeights, sampleOrderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.5, 0.5, 0.5}), 4 , 1e-6);
+    }
+
+    // as above, but unordered (check that weights are ordered correctly)
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumAllEqualDisorderedWeights) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(sampleUnorderedNoWeights, weightsHasWeights, sampleUnorderedNoWeights,
+            TVector<double>{3, 10}, TVector<double>{0.5, 0.5, 0.5}), 4 , 1e-6);
+    }
+
+    // test simple case, but there are entries for each different quantile
+    Y_UNIT_TEST(TCalcPiecewiseQuantileMinimumMultiAllWindows) {
+        UNIT_ASSERT_DOUBLES_EQUAL(CalcPiecewiseQuantileMinimum(diffs, weightsNoWeights, sampleOrderedNoWeights,
+            TVector<double>{1.5, 3.5}, TVector<double>{0.1, 0.5, 0.9}), 0.3, 1e-6);
+    }
+
+}

--- a/catboost/libs/train_lib/options_helper.cpp
+++ b/catboost/libs/train_lib/options_helper.cpp
@@ -363,7 +363,7 @@ static void AdjustBoostFromAverageDefaultValue(
         && !continueFromModel
         && EqualToOneOf(
             catBoostOptions->LossFunctionDescription->GetLossFunction(),
-            ELossFunction::RMSE, ELossFunction::MAE, ELossFunction::Quantile, ELossFunction::MAPE,
+            ELossFunction::RMSE, ELossFunction::MAE, ELossFunction::PiecewiseQuantile, ELossFunction::Quantile, ELossFunction::MAPE,
             ELossFunction::MultiQuantile, ELossFunction::MultiRMSE, ELossFunction::MultiRMSEWithMissingValues)
     ) {
         catBoostOptions->BoostingOptions->BoostFromAverage.Set(true);

--- a/catboost/private/libs/algo/approx_calcer.cpp
+++ b/catboost/private/libs/algo/approx_calcer.cpp
@@ -687,19 +687,29 @@ static void CalcExactLeafDeltas(
     TConstArrayRef<float> targets,
     TConstArrayRef<float> weights,
     TVector<double>* leafDeltas) {
+    const bool needOrigTargets = (lossDescription.GetLossFunction() == ELossFunction::PiecewiseQuantile);
     TVector<TVector<float>> leafSamples(leafCount);
     TVector<TVector<float>> leafWeights(leafCount);
+    TVector<TVector<float>> leafOrigTargets;
+    if (needOrigTargets) {
+        leafOrigTargets.resize(leafCount);
+    }
 
     for (size_t i = 0; i < sampleCount; i++) {
         Y_ASSERT(indices[i] < leafSamples.size());
         leafSamples[indices[i]].emplace_back(targets[i] - approxes[i]);
         leafWeights[indices[i]].emplace_back(weights[i]);
+        if (needOrigTargets) {
+            leafOrigTargets[indices[i]].emplace_back(targets[i]);
+        }
     }
 
     Y_ASSERT(leafCount == leafDeltas->size());
     for (size_t i = 0; i < leafCount; i++) {
         double& leafDelta = (*leafDeltas)[i];
-        leafDelta = *NCB::CalcOneDimensionalOptimumConstApprox(lossDescription, leafSamples[i], leafWeights[i]);
+        leafDelta = *NCB::CalcOneDimensionalOptimumConstApprox(
+            lossDescription, leafSamples[i], leafWeights[i],
+            needOrigTargets ? leafOrigTargets[i] : TConstArrayRef<float>());
     }
 }
 

--- a/catboost/private/libs/algo/approx_calcer/leafwise_approx_calcer.cpp
+++ b/catboost/private/libs/algo/approx_calcer/leafwise_approx_calcer.cpp
@@ -188,7 +188,7 @@ static void CalcExactLeafDeltas(
     for (int i = 0; i < objectsCount; i++) {
         samples[i] = labels[i] - approxes[i];
     }
-    leafDelta = *NCB::CalcOneDimensionalOptimumConstApprox(lossDescription, samples, weights);
+    leafDelta = *NCB::CalcOneDimensionalOptimumConstApprox(lossDescription, samples, weights, labels);
 }
 
 static void CalcLeafValuesSimple(

--- a/catboost/private/libs/algo/target_classifier.cpp
+++ b/catboost/private/libs/algo/target_classifier.cpp
@@ -62,6 +62,7 @@ TTargetClassifier BuildTargetClassifier(
         case ELossFunction::MultiRMSE:
         case ELossFunction::SurvivalAft:
         case ELossFunction::RMSEWithUncertainty:
+        case ELossFunction::PiecewiseQuantile:
         case ELossFunction::Quantile:
         case ELossFunction::MultiQuantile:
         case ELossFunction::Expectile:

--- a/catboost/private/libs/algo/tensor_search_helpers.cpp
+++ b/catboost/private/libs/algo/tensor_search_helpers.cpp
@@ -7,6 +7,7 @@
 #include <catboost/libs/data/objects.h>
 #include <catboost/libs/helpers/restorable_rng.h>
 #include <catboost/private/libs/options/catboost_options.h>
+#include <catboost/private/libs/options/loss_description.h>
 #include <catboost/libs/helpers/distribution_helpers.h>
 
 #include <library/cpp/threading/local_executor/local_executor.h>
@@ -183,6 +184,19 @@ THolder<IDerCalcer> BuildError(
             double alpha = lossParams.contains("alpha") ? FromString<float>(lossParams.at("alpha")) : 0.5;
             double delta = lossParams.contains("delta") ? FromString<float>(lossParams.at("delta")) : 1e-6;
             return MakeHolder<TQuantileError>(alpha, delta, isStoreExpApprox);
+        }
+        case ELossFunction::PiecewiseQuantile: {
+            const auto& lossParams = params.LossFunctionDescription->GetLossParamsMap();
+            const auto badParam = FindIf(lossParams, [] (const auto& param) {
+                return !EqualToOneOf(param.first, "boundaries", "quantiles", "delta");
+            });
+            CB_ENSURE(badParam == lossParams.end(), "Invalid loss description " << ToString(badParam->first));
+            auto boundaries = NCatboostOptions::GetBoundariesPiecewiseQuantile(lossParams);
+            auto quantiles = NCatboostOptions::GetQuantilesPiecewiseQuantile(lossParams);
+            CB_ENSURE(quantiles.size() == boundaries.size() + 1,
+                "quantiles count (" << quantiles.size() << ") must equal boundaries count + 1 (" << boundaries.size() + 1 << ")");
+            double delta = NCatboostOptions::GetParamOrDefault(lossParams, "delta", 1e-6);
+            return MakeHolder<TPiecewiseQuantileError>(std::move(boundaries), std::move(quantiles), delta, isStoreExpApprox);
         }
         case ELossFunction::GroupQuantile: {
             const auto& lossParams = params.LossFunctionDescription->GetLossParamsMap();

--- a/catboost/private/libs/algo_helpers/error_functions.h
+++ b/catboost/private/libs/algo_helpers/error_functions.h
@@ -4,6 +4,7 @@
 #include "custom_objective_descriptor.h"
 #include "ders_holder.h"
 #include "hessian.h"
+#include "quantile_selection.h"
 #include "survival_aft_utils.h"
 
 #include <catboost/private/libs/data_types/pair.h>
@@ -493,6 +494,65 @@ private:
     }
 
     double CalcDer3(double /*approx*/, float /*target*/) const override {
+        return QUANTILE_DER2_AND_DER3;
+    }
+};
+
+class TPiecewiseQuantileError final : public IDerCalcer
+{
+public:
+    static constexpr double QUANTILE_DER2_AND_DER3 = 0.0;
+
+public:
+    const TVector<double> Boundaries;
+    const TVector<double> Quantiles;
+    const double Delta;
+
+public:
+    explicit TPiecewiseQuantileError(bool isExpApprox)
+        : IDerCalcer(isExpApprox)
+        , Boundaries({0})
+        , Quantiles({1, 0.5})
+        , Delta(1e-6)
+    {
+        CB_ENSURE(isExpApprox == false, "Approx format does not match");
+    }
+
+    TPiecewiseQuantileError(TVector<double> boundaries, TVector<double> quantiles, double delta, bool isExpApprox)
+        : IDerCalcer(isExpApprox)
+        , Boundaries(std::move(boundaries))
+        , Quantiles(std::move(quantiles))
+        , Delta(delta)
+    {
+        CB_ENSURE(Quantiles.size() == Boundaries.size() + 1,
+            "quantiles count must equal boundaries count + 1");
+        for (size_t i = 1; i < Boundaries.size(); ++i) {
+            Y_ASSERT(Boundaries[i - 1] < Boundaries[i]);
+        }
+        for (const auto& q : Quantiles) {
+            Y_ASSERT(q > -1e-6 && q < 1.0 + 1e-6);
+        }
+        Y_ASSERT(Delta >= 0 && Delta <= 1e-2);
+        CB_ENSURE(isExpApprox == false, "Approx format does not match");
+    }
+
+private:
+    double CalcDer(double approx, float target) const override
+    {
+        const double alpha = select_quantile(Boundaries, Quantiles, target);
+        const double val = target - approx;
+        if (abs(val) < Delta)
+            return 0;
+        return (target - approx > 0) ? alpha : -(1 - alpha);
+    }
+
+    double CalcDer2(double /*approx*/, float /*target*/) const override
+    {
+        return QUANTILE_DER2_AND_DER3;
+    }
+
+    double CalcDer3(double /*approx*/, float /*target*/) const override
+    {
         return QUANTILE_DER2_AND_DER3;
     }
 };

--- a/catboost/private/libs/algo_helpers/quantile_selection.h
+++ b/catboost/private/libs/algo_helpers/quantile_selection.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <util/generic/array_ref.h>
+
+/*
+Helper function for the piecewise quantile loss, corresponding metric and exact leaf estimate.
+Selects one of N quantile levels based on where "value" falls relative to the sorted boundaries.
+
+Given N-1 boundaries and N quantiles:
+  - value <= boundaries[0]           -> quantiles[0]
+  - boundaries[i-1] < value <= boundaries[i] -> quantiles[i]
+  - value > boundaries[N-2]          -> quantiles[N-1]
+*/
+static inline double select_quantile(
+    TConstArrayRef<double> boundaries,
+    TConstArrayRef<double> quantiles,
+    double value)
+{
+    for (size_t i = 0; i < boundaries.size(); ++i) {
+        if (value <= boundaries[i]) {
+            return quantiles[i];
+        }
+    }
+    return quantiles[boundaries.size()];
+}

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.darwin-arm64.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.darwin-arm64.txt
@@ -42,6 +42,8 @@ target_link_options(catboost-private-libs-algo_helpers-ut PRIVATE
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.darwin-x86_64.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.darwin-x86_64.txt
@@ -43,6 +43,8 @@ target_link_options(catboost-private-libs-algo_helpers-ut PRIVATE
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-aarch64-cuda.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-aarch64-cuda.txt
@@ -46,6 +46,8 @@ target_link_options(catboost-private-libs-algo_helpers-ut PRIVATE
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-aarch64.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-aarch64.txt
@@ -45,6 +45,8 @@ target_link_options(catboost-private-libs-algo_helpers-ut PRIVATE
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-ppc64le-cuda.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-ppc64le-cuda.txt
@@ -46,6 +46,8 @@ target_link_options(catboost-private-libs-algo_helpers-ut PRIVATE
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-ppc64le.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-ppc64le.txt
@@ -45,6 +45,8 @@ target_link_options(catboost-private-libs-algo_helpers-ut PRIVATE
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-x86_64-cuda.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-x86_64-cuda.txt
@@ -48,6 +48,8 @@ target_link_options(catboost-private-libs-algo_helpers-ut PRIVATE
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-x86_64.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.linux-x86_64.txt
@@ -47,6 +47,8 @@ target_link_options(catboost-private-libs-algo_helpers-ut PRIVATE
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.windows-x86_64-cuda.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.windows-x86_64-cuda.txt
@@ -35,6 +35,8 @@ target_allocator(catboost-private-libs-algo_helpers-ut
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/CMakeLists.windows-x86_64.txt
+++ b/catboost/private/libs/algo_helpers/ut/CMakeLists.windows-x86_64.txt
@@ -35,6 +35,8 @@ target_allocator(catboost-private-libs-algo_helpers-ut
 target_sources(catboost-private-libs-algo_helpers-ut PRIVATE
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/pairwise_leaves_calculation_ut.cpp
   ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/multiquantile_derivatives_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+  ${PROJECT_SOURCE_DIR}/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
 )
 
 

--- a/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
+++ b/catboost/private/libs/algo_helpers/ut/piecewise_quantile_error_ut.cpp
@@ -1,0 +1,54 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <catboost/private/libs/algo_helpers/error_functions.h>
+
+
+Y_UNIT_TEST_SUITE(TPiecewiseQuantileErrorTest) {
+
+    double q1 = 0.2;
+    double q2 = 0.5;
+    double q3 = 0.8;
+
+    TVector<float> targets={1.,1.,3.,6.,7.,11.,12.};
+    TVector<double> approxes={1.0001,3.,1.,7.,6.,12.,11.};
+    TVector<double> ders1(7);
+    TVector<double> ders2(7);
+    TVector<double> ders3(7);
+
+    TPiecewiseQuantileError error(TVector<double>{5., 10.}, TVector<double>{q1, q2, q3}, 1e-3, false);
+    ui32 docCount = SafeIntegerCast<ui32>(targets.size());
+    TVector<TDers> derivatives(docCount);
+
+    //check that small values are forced to zero
+    Y_UNIT_TEST(PiecewiseQuantileErrorDelta) {
+        error.CalcDersRange(0,docCount,true,approxes.data(),nullptr,targets.data(),nullptr,derivatives.data());
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[0].Der1,0.,1e-6);
+    }
+    //check that we get the right derivative for each window, check right and left derivatives
+    Y_UNIT_TEST(PiecewiseQuantileErrorQ1L) {
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[1].Der1,q1-1.,1e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileErrorQ1R) {
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[2].Der1,q1,1e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileErrorQ2R) {
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[3].Der1,q2-1.,1e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileErrorQ2L) {
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[4].Der1,q2,1e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileErrorQ3R) {
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[5].Der1,q3-1.,1e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileErrorQ3L) {
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[6].Der1,q3,1e-6);
+    }
+
+    //check that second and third derivative are zero
+    Y_UNIT_TEST(PiecewiseQuantileErrorDer2) {
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[1].Der2,0,1e-6);
+    }
+    Y_UNIT_TEST(PiecewiseQuantileErrorDer3) {
+        UNIT_ASSERT_DOUBLES_EQUAL(derivatives[1].Der3,0,1e-6);
+    }
+
+}

--- a/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
+++ b/catboost/private/libs/algo_helpers/ut/quantile_selection_ut.cpp
@@ -1,0 +1,23 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <catboost/private/libs/algo_helpers/quantile_selection.h>
+
+Y_UNIT_TEST_SUITE(TQuantileSelectionTest) {
+    Y_UNIT_TEST(QuantileSelectionFirst) {
+        UNIT_ASSERT_DOUBLES_EQUAL(select_quantile({1., 2.}, {-1., 0., 1.}, 0.5), -1., 1e-6);
+    }
+    Y_UNIT_TEST(QuantileSelectionSecond) {
+        UNIT_ASSERT_DOUBLES_EQUAL(select_quantile({1., 2.}, {-1., 0., 1.}, 1.5), 0., 1e-6);
+    }
+    Y_UNIT_TEST(QuantileSelectionThird) {
+        UNIT_ASSERT_DOUBLES_EQUAL(select_quantile({1., 2.}, {-1., 0., 1.}, 2.5), 1., 1e-6);
+    }
+    Y_UNIT_TEST(QuantileSelectionOnBoundary) {
+        UNIT_ASSERT_DOUBLES_EQUAL(select_quantile({1., 2.}, {-1., 0., 1.}, 1.0), -1., 1e-6);
+    }
+    Y_UNIT_TEST(QuantileSelectionSingleSegment) {
+        UNIT_ASSERT_DOUBLES_EQUAL(select_quantile({}, {0.5}, 42.0), 0.5, 1e-6);
+    }
+    Y_UNIT_TEST(QuantileSelectionFourSegments) {
+        UNIT_ASSERT_DOUBLES_EQUAL(select_quantile({1., 2., 3.}, {0.1, 0.2, 0.3, 0.4}, 2.5), 0.3, 1e-6);
+    }
+}

--- a/catboost/private/libs/distributed/master.cpp
+++ b/catboost/private/libs/distributed/master.cpp
@@ -577,8 +577,13 @@ static void UpdateLeavesExact(
     const int approxDimension = ctx->LearnProgress->ApproxDimension;
     const auto lossFunction = ctx->Params.LossFunctionDescription;
 
-    Y_ASSERT(EqualToOneOf(lossFunction->GetLossFunction(), ELossFunction::Quantile, ELossFunction::MAE, ELossFunction::MAPE, ELossFunction::RMSPE));
+    Y_ASSERT(EqualToOneOf(lossFunction->GetLossFunction(), ELossFunction::Quantile, ELossFunction::PiecewiseQuantile, ELossFunction::MAE, ELossFunction::MAPE, ELossFunction::RMSPE));
     averageLeafValues->resize(approxDimension, TVector<double>(leafCount));
+    // PiecewiseQuantile falls back to alpha=0.5/delta=0.0 (MAE) in this distributed
+    // exact-leaves path because per-sample alpha selection requires origTarget which is not
+    // available on workers. This path is only reached when leaf_estimation_method=Exact is
+    // explicitly forced in a multi-host setup; the default Gradient estimation works correctly
+    // in distributed mode since each worker computes derivatives locally with its own origTarget.
     double alpha = 0.5;
     double delta = 0.0;
     if (const auto quantileError = dynamic_cast<const TQuantileError*>(&error)) {

--- a/catboost/private/libs/documents_importance/ders_helpers.cpp
+++ b/catboost/private/libs/documents_importance/ders_helpers.cpp
@@ -83,6 +83,10 @@ static TEvaluateDerivativesFunc GetEvaluateDerivativesFunc(ELossFunction lossFun
         case ELossFunction::MAE:
         case ELossFunction::Quantile:
             return EvaluateDerivativesForError<TQuantileError>;
+        case ELossFunction::PiecewiseQuantile:
+            // Uses default constructor -- document importance uses default boundaries/quantiles,
+            // not the user's custom params, because loss params aren't threaded here.
+            return EvaluateDerivativesForError<TPiecewiseQuantileError>;
         case ELossFunction::Expectile:
             return EvaluateDerivativesForError<TExpectileError>;
         case ELossFunction::LogLinQuantile:

--- a/catboost/private/libs/options/catboost_options.cpp
+++ b/catboost/private/libs/options/catboost_options.cpp
@@ -114,6 +114,7 @@ static std::tuple<ui32, ui32, ELeavesEstimation, double> GetEstimationMethodDefa
         case ELossFunction::MAPE:
         case ELossFunction::RMSPE:
         case ELossFunction::Quantile:
+        case ELossFunction::PiecewiseQuantile:
         case ELossFunction::GroupQuantile:
         case ELossFunction::MultiQuantile:
         case ELossFunction::LogLinQuantile: {
@@ -286,7 +287,7 @@ void NCatboostOptions::TCatBoostOptions::SetLeavesEstimationDefault() {
     if (lossFunctionConfig.GetLossFunction() == ELossFunction::UserQuerywiseMetric) {
         treeConfig.PairwiseNonDiagReg.SetDefault(0);
     }
-    const bool useExact = EqualToOneOf(lossFunctionConfig.GetLossFunction(), ELossFunction::MAE, ELossFunction::MAPE, ELossFunction::RMSPE, ELossFunction::Quantile, ELossFunction::GroupQuantile, ELossFunction::MultiQuantile)
+    const bool useExact = EqualToOneOf(lossFunctionConfig.GetLossFunction(), ELossFunction::MAE, ELossFunction::MAPE, ELossFunction::RMSPE, ELossFunction::Quantile, ELossFunction::PiecewiseQuantile, ELossFunction::GroupQuantile, ELossFunction::MultiQuantile)
             && SystemOptions->IsSingleHost()
             && (
                 (TaskType == ETaskType::GPU && BoostingOptions->BoostingType == EBoostingType::Plain)
@@ -342,8 +343,8 @@ void NCatboostOptions::TCatBoostOptions::SetLeavesEstimationDefault() {
 
     if (treeConfig.LeavesEstimationMethod == ELeavesEstimation::Exact) {
         auto loss = lossFunctionConfig.GetLossFunction();
-        CB_ENSURE(EqualToOneOf(loss, ELossFunction::Quantile, ELossFunction::GroupQuantile, ELossFunction::MAE, ELossFunction::MAPE, ELossFunction::RMSPE, ELossFunction::LogCosh, ELossFunction::MultiQuantile),
-            "Exact method is only available for Quantile, GroupQuantile, MultiQuantile, MAE, MAPE, RMSPE and LogCosh loss functions.");
+        CB_ENSURE(EqualToOneOf(loss, ELossFunction::Quantile, ELossFunction::PiecewiseQuantile, ELossFunction::GroupQuantile, ELossFunction::MAE, ELossFunction::MAPE, ELossFunction::RMSPE, ELossFunction::LogCosh, ELossFunction::MultiQuantile),
+            "Exact method is only available for Quantile, PiecewiseQuantile, GroupQuantile, MultiQuantile, MAE, MAPE, RMSPE and LogCosh loss functions.");
         CB_ENSURE(
             BoostingOptions->BoostingType == EBoostingType::Plain || TaskType == ETaskType::CPU,
             "Exact leaf estimation method don't work with ordered boosting on GPU"
@@ -483,7 +484,7 @@ static void ValidateCtrTargetBinarization(
 {
     if (ctrTargetBinarization->BorderCount > 1) {
         CB_ENSURE(EqualToOneOf(lossFunction,
-                      ELossFunction::RMSE, ELossFunction::LogCosh, ELossFunction::Quantile, ELossFunction::MultiQuantile,
+                      ELossFunction::RMSE, ELossFunction::LogCosh, ELossFunction::Quantile, ELossFunction::PiecewiseQuantile, ELossFunction::MultiQuantile,
                       ELossFunction::LogLinQuantile, ELossFunction::Poisson,
                       ELossFunction::MAPE, ELossFunction::MAE, ELossFunction::MultiClass,
                       ELossFunction::MultiRMSE, ELossFunction::MultiRMSEWithMissingValues, ELossFunction::SurvivalAft, ELossFunction::RMSPE),
@@ -591,6 +592,7 @@ static void EnsureNewtonIsAvailable(ETaskType taskType, const NCatboostOptions::
         ELossFunction::StochasticFilter,
         ELossFunction::StochasticRank,
         ELossFunction::Quantile,
+        ELossFunction::PiecewiseQuantile,
         ELossFunction::MultiQuantile,
         ELossFunction::MAE,
         ELossFunction::LogLinQuantile,
@@ -703,10 +705,10 @@ void NCatboostOptions::TCatBoostOptions::Validate() const {
     if (BoostingOptions->BoostFromAverage.Get()) {
         // we may adjust non-set BoostFromAverage in data dependant tuning
         CB_ENSURE(EqualToOneOf(lossFunction, ELossFunction::RMSE, ELossFunction::Logloss,
-            ELossFunction::CrossEntropy, ELossFunction::Quantile, ELossFunction::MultiQuantile, ELossFunction::MAE, ELossFunction::MAPE,
+            ELossFunction::CrossEntropy, ELossFunction::Quantile, ELossFunction::PiecewiseQuantile, ELossFunction::MultiQuantile, ELossFunction::MAE, ELossFunction::MAPE,
             ELossFunction::MultiRMSE, ELossFunction::MultiRMSEWithMissingValues, ELossFunction::RMSPE),
             "You can use boost_from_average only for these loss functions now: " <<
-            "RMSE, Logloss, CrossEntropy, Quantile, MultiQuantile, MAE, MAPE, MultiRMSE, MultiRMSEWithMissingValues or RMSPE.");
+            "RMSE, Logloss, CrossEntropy, Quantile, PiecewiseQuantile, MultiQuantile, MAE, MAPE, MultiRMSE, MultiRMSEWithMissingValues or RMSPE.");
         CB_ENSURE(SystemOptions->IsSingleHost(), "You can use boost_from_average only on single host now.");
     }
 

--- a/catboost/private/libs/options/enum_helpers.cpp
+++ b/catboost/private/libs/options/enum_helpers.cpp
@@ -178,6 +178,9 @@ MakeRegister(LossInfos,
         EMetricAttribute::IsRegression
         | EMetricAttribute::HasGpuImplementation
     ),
+    Registree(PiecewiseQuantile,
+        EMetricAttribute::IsRegression
+    ),
     Registree(MultiQuantile,
         EMetricAttribute::IsRegression
     ),
@@ -536,6 +539,7 @@ static const TVector<ELossFunction> RegressionObjectives = {
     ELossFunction::RMSEWithUncertainty,
     ELossFunction::MAE,
     ELossFunction::Quantile,
+    ELossFunction::PiecewiseQuantile,
     ELossFunction::MultiQuantile,
     ELossFunction::LogLinQuantile,
     ELossFunction::Expectile,

--- a/catboost/private/libs/options/enums.h
+++ b/catboost/private/libs/options/enums.h
@@ -131,6 +131,7 @@ enum class ELossFunction {
     Lq,
     MAE,
     Quantile,
+    PiecewiseQuantile,
     MultiQuantile,
     Expectile,
     LogLinQuantile,

--- a/catboost/private/libs/options/loss_description.cpp
+++ b/catboost/private/libs/options/loss_description.cpp
@@ -111,6 +111,26 @@ TVector<double> NCatboostOptions::GetAlphaMultiQuantile(const TMap<TString, TStr
     return alpha;
 }
 
+TVector<double> NCatboostOptions::GetBoundariesPiecewiseQuantile(const TMap<TString, TString>& lossParams) {
+    const TString defaultBoundaries("0");
+    const TStringBuf param(lossParams.contains("boundaries") ? lossParams.at("boundaries") : defaultBoundaries);
+    TVector<double> boundaries;
+    for (const auto& value : StringSplitter(param).Split(',').SkipEmpty()) {
+        boundaries.emplace_back(FromString<double>(value.Token()));
+    }
+    return boundaries;
+}
+
+TVector<double> NCatboostOptions::GetQuantilesPiecewiseQuantile(const TMap<TString, TString>& lossParams) {
+    const TString defaultQuantiles("1,0.5");
+    const TStringBuf param(lossParams.contains("quantiles") ? lossParams.at("quantiles") : defaultQuantiles);
+    TVector<double> quantiles;
+    for (const auto& value : StringSplitter(param).Split(',').SkipEmpty()) {
+        quantiles.emplace_back(FromString<double>(value.Token()));
+    }
+    return quantiles;
+}
+
 double NCatboostOptions::GetAlphaQueryCrossEntropy(const TMap<TString, TString>& lossParams) {
     return GetParamOrDefault(lossParams, "alpha", 0.95);
 }

--- a/catboost/private/libs/options/loss_description.h
+++ b/catboost/private/libs/options/loss_description.h
@@ -112,6 +112,9 @@ namespace NCatboostOptions {
 
     TVector<double> GetAlphaMultiQuantile(const TMap<TString, TString>& lossParams);
 
+    TVector<double> GetBoundariesPiecewiseQuantile(const TMap<TString, TString>& lossParams);
+    TVector<double> GetQuantilesPiecewiseQuantile(const TMap<TString, TString>& lossParams);
+
     double GetAlphaQueryCrossEntropy(const TMap<TString, TString>& lossParams);
     double GetAlphaQueryCrossEntropy(const TLossDescription& lossFunctionConfig);
     void GetApproxScaleQueryCrossEntropy(


### PR DESCRIPTION
This PR adds a new loss function called **PiecewiseQuantile** and closes #3053 . It uses different quantile values based on where a sample’s target/ground truth value falls within user-provided intervals.

As an example:
`PiecewiseQuantile:boundaries=0,1;quantiles=0.25,0.5,0.75`
This assigns:

- alpha=0.25 when y <= 0
- alpha=0.5 when 0 < y <= 1
- alpha=0.75 when y > 1.

The length of these input lists are not fixed. To be clear, these quantiles are with respect to the other samples in the respective intervals.

We include the loss function, its gradients, and the corresponding metric. We also include unit tests for all of our additions. 

 