### PR TITLE
Add Bazel build files for CatBoost C++ model inference library

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,18 @@
+# CatBoost Bazel build configuration
+
+# Add workspace root to include path so workspace-relative includes work:
+#   e.g. #include "util/generic/string.h" from any compilation unit
+build --copt=-I.
+
+# C++20 standard (matches CMakeLists.txt)
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20
+
+# Use C17 for C sources
+build --conlyopt=-std=c17
+
+# Silence warnings from vendored third-party libraries when building catboost targets
+build --per_file_copt=contrib/.*@-Wno-everything
+
+# Disable default Abseil / proto rules that may be auto-loaded
+common --incompatible_enable_cc_toolchain_resolution=false

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,15 @@
+# Root BUILD file for CatBoost
+
+# Convenience alias to build the static catboost model inference library
+alias(
+    name = "catboostmodel_static",
+    actual = "//catboost/libs/model_interface/static:catboostmodel_static",
+    visibility = ["//visibility:public"],
+)
+
+# Convenience alias for the shared catboost model library
+alias(
+    name = "catboostmodel",
+    actual = "//catboost/libs/model_interface:catboostmodel",
+    visibility = ["//visibility:public"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "catboost")

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,1 @@
+# Bazel macros package — no build targets here.

--- a/bazel/enum_serialization.bzl
+++ b/bazel/enum_serialization.bzl
@@ -1,0 +1,53 @@
+"""Bazel macro for generating enum serialization code via the enum_parser tool.
+
+The enum_parser tool reads C++ header files, extracts enum definitions, and
+generates a .cpp file containing ToString / FromString / Out overloads.
+
+Usage:
+    generate_enum_serialization(
+        name      = "my_lib_enum_serialization",
+        src       = "my_header.h",
+        includes  = ["my/package/my_header.h"],
+        extra_headers = ["other_needed_header.h"],
+    )
+"""
+
+def generate_enum_serialization(name, src, includes = [], extra_headers = [], visibility = None):
+    """Generate enum serialization .cpp source from a C++ header.
+
+    Args:
+        name:          Bazel target name for the generated cc_library.
+        src:           The header file label containing enums to serialize.
+        includes:      List of include paths to pass to the enum parser
+                       (workspace-relative paths used in the generated #include
+                       directives).
+        extra_headers: Additional header file labels that the generated file
+                       should include.
+        visibility:    Bazel visibility.
+    """
+    out_cpp = name + ".cpp"
+
+    include_flags = " ".join(["--include-path " + p for p in includes])
+
+    native.genrule(
+        name = name + "_gen",
+        srcs = [src] + extra_headers,
+        outs = [out_cpp],
+        cmd = """
+            $(location //tools/enum_parser/enum_parser) \\
+                $(location {src}) \\
+                {include_flags} \\
+                --output-file $@
+        """.format(src = src, include_flags = include_flags),
+        tools = ["//tools/enum_parser/enum_parser"],
+    )
+
+    native.cc_library(
+        name = name,
+        srcs = [out_cpp],
+        deps = [
+            "//tools/enum_parser/enum_serialization_runtime",
+            "//util",
+        ],
+        visibility = visibility or ["//visibility:public"],
+    )

--- a/bazel/flatbuffers.bzl
+++ b/bazel/flatbuffers.bzl
@@ -1,0 +1,55 @@
+"""Bazel macro for generating C++ code from FlatBuffers schema files (.fbs).
+
+Usage:
+    flatbuffers_library(
+        name = "my_fbs",
+        srcs = ["my_schema.fbs"],
+        include_paths = ["path/to/includes"],
+    )
+"""
+
+def flatbuffers_library(name, srcs, include_paths = [], deps = [], visibility = None):
+    """Generate C++ headers and sources from FlatBuffers .fbs schema files.
+
+    Args:
+        name:          Bazel target name.
+        srcs:          List of .fbs schema files.
+        include_paths: Additional include paths passed to flatc via -I.
+        deps:          Additional flatbuffers_library deps (for schema imports).
+        visibility:    Bazel visibility.
+    """
+    outs_h = []
+    outs_cpp = []
+
+    for src in srcs:
+        # Derive base name without extension
+        base = src.replace(".fbs", "")
+        outs_h.append(base + ".fbs.h")
+        outs_cpp.append(base + ".fbs.cpp")
+
+    include_flags = " ".join(["-I " + p for p in include_paths])
+
+    native.genrule(
+        name = name + "_gen",
+        srcs = srcs,
+        outs = outs_h + outs_cpp,
+        cmd = """
+            FLATC=$(location //contrib/libs/flatbuffers/flatc)
+            for fbs in $(SRCS); do
+                $$FLATC --cpp --gen-object-api --reflect-names {include_flags} \\
+                    --filename-suffix ".fbs" \\
+                    -o $(@D) $$fbs
+            done
+        """.format(include_flags = include_flags),
+        tools = ["//contrib/libs/flatbuffers/flatc"],
+    )
+
+    native.cc_library(
+        name = name,
+        srcs = outs_cpp,
+        hdrs = outs_h,
+        deps = deps + [
+            "//contrib/libs/flatbuffers",
+        ],
+        visibility = visibility,
+    )

--- a/catboost/libs/cat_feature/BUILD.bazel
+++ b/catboost/libs/cat_feature/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "cat_feature",
+    srcs = ["cat_feature.cpp"],
+    hdrs = ["cat_feature.h"],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/column_description/BUILD.bazel
+++ b/catboost/libs/column_description/BUILD.bazel
@@ -1,0 +1,28 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "column_enum_serialization",
+    src = "column.h",
+    includes = ["catboost/libs/column_description/column.h"],
+)
+
+cc_library(
+    name = "column_description",
+    srcs = [
+        "cd_parser.cpp",
+        "column.cpp",
+        "feature_tag.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":column_enum_serialization",
+        "//catboost/libs/helpers",
+        "//catboost/libs/logging",
+        "//catboost/private/libs/data_util",
+        "//library/cpp/binsaver",
+        "//library/cpp/json",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/helpers/BUILD.bazel
+++ b/catboost/libs/helpers/BUILD.bazel
@@ -1,0 +1,50 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "helpers_sparse_array_enum_serialization",
+    src = "sparse_array.h",
+    includes = ["catboost/libs/helpers/sparse_array.h"],
+)
+
+generate_enum_serialization(
+    name = "helpers_distribution_enum_serialization",
+    src = "distribution_helpers.h",
+    includes = ["catboost/libs/helpers/distribution_helpers.h"],
+)
+
+cc_library(
+    name = "helpers",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = [
+            "**/*_ut*.cpp",
+            "**/ut/**",
+        ],
+    ),
+    hdrs = glob(
+        ["*.h"],
+        exclude = ["**/ut/**"],
+    ),
+    deps = [
+        ":helpers_distribution_enum_serialization",
+        ":helpers_sparse_array_enum_serialization",
+        "//catboost/libs/helpers/flatbuffers:helpers_flatbuffers",
+        "//catboost/libs/logging",
+        "//catboost/private/libs/data_types",
+        "//catboost/private/libs/data_util",
+        "//catboost/private/libs/index_range",
+        "//contrib/libs/flatbuffers",
+        "//library/cpp/binsaver",
+        "//library/cpp/dbg_output",
+        "//library/cpp/deprecated/atomic",
+        "//library/cpp/digest/crc32c",
+        "//library/cpp/digest/md5",
+        "//library/cpp/fast_exp",
+        "//library/cpp/json",
+        "//library/cpp/malloc/api",
+        "//library/cpp/threading/local_executor",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/helpers/flatbuffers/BUILD.bazel
+++ b/catboost/libs/helpers/flatbuffers/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//bazel:flatbuffers.bzl", "flatbuffers_library")
+
+flatbuffers_library(
+    name = "helpers_flatbuffers",
+    srcs = ["guid.fbs"],
+    include_paths = [
+        "catboost/libs/helpers/flatbuffers",
+        ".",
+    ],
+    deps = [
+        "//contrib/libs/flatbuffers",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/logging/BUILD.bazel
+++ b/catboost/libs/logging/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "logging_level_enum_serialization",
+    src = "logging_level.h",
+    includes = ["catboost/libs/logging/logging_level.h"],
+)
+
+cc_library(
+    name = "logging",
+    srcs = ["logging.cpp"],
+    hdrs = [
+        "logging.h",
+        "logging_level.h",
+        "profile_info.h",
+    ],
+    deps = [
+        ":logging_level_enum_serialization",
+        "//library/cpp/logger",
+        "//library/cpp/logger/global:logger_global",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/model/BUILD.bazel
+++ b/catboost/libs/model/BUILD.bazel
@@ -1,0 +1,61 @@
+# catboost-libs-model: Core CatBoost model representation and CPU evaluation.
+#
+# Provides TFullModel — the main model container — together with CPU-based
+# tree evaluation, CTR handling, FlatBuffers serialization/deserialization,
+# and model export functionality.
+
+cc_library(
+    name = "model",
+    srcs = glob(
+        [
+            "*.cpp",
+            "cpu/*.cpp",
+            "model_export/*.cpp",
+        ],
+        exclude = [
+            "**/*_ut*.cpp",
+            "**/ut/**",
+            # CUDA evaluation is built separately
+            "cuda/**",
+        ],
+    ),
+    hdrs = glob(
+        [
+            "*.h",
+            "cpu/*.h",
+            "model_export/*.h",
+        ],
+        exclude = ["**/ut/**"],
+    ),
+    deps = [
+        "//catboost/libs/cat_feature",
+        "//catboost/libs/helpers",
+        "//catboost/libs/logging",
+        "//catboost/libs/model/flatbuffers:model_flatbuffers",
+        "//catboost/private/libs/ctr_description",
+        "//catboost/private/libs/embedding_features",
+        "//catboost/private/libs/options",
+        "//catboost/private/libs/text_features",
+        "//contrib/libs/flatbuffers",
+        "//library/cpp/binsaver",
+        "//library/cpp/containers/dense_hash",
+        "//library/cpp/dbg_output",
+        "//library/cpp/json",
+        "//library/cpp/object_factory",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Global variant: registers model importers / exporters via static initializers.
+cc_library(
+    name = "model_global",
+    srcs = [
+        "formula_evaluator.cpp",
+        "model_import_interface.cpp",
+    ],
+    deps = [":model"],
+    alwayslink = True,
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/model/flatbuffers/BUILD.bazel
+++ b/catboost/libs/model/flatbuffers/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//bazel:flatbuffers.bzl", "flatbuffers_library")
+
+flatbuffers_library(
+    name = "model_flatbuffers",
+    srcs = [
+        "ctr_data.fbs",
+        "features.fbs",
+        "model.fbs",
+    ],
+    include_paths = [
+        "catboost/libs/model/flatbuffers",
+        "catboost/libs/helpers/flatbuffers",
+        ".",
+    ],
+    deps = [
+        "//catboost/libs/helpers/flatbuffers:helpers_flatbuffers",
+        "//contrib/libs/flatbuffers",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/model_interface/BUILD.bazel
+++ b/catboost/libs/model_interface/BUILD.bazel
@@ -1,0 +1,49 @@
+# catboostmodel — shared library and C API for model inference.
+#
+# Exported symbols are controlled by calcer.exports.
+
+cc_library(
+    name = "catboostmodel_impl",
+    srcs = ["c_api.cpp"],
+    hdrs = ["c_api.h"],
+    defines = ["CATBOOST_API_EXPORTS"],
+    deps = [
+        "//catboost/libs/cat_feature",
+        "//catboost/libs/model",
+        "//catboost/libs/model:model_global",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "catboostmodel",
+    roots = [":catboostmodel_impl"],
+    exports_filter = ["//catboost/libs/..."],
+    user_link_flags = select({
+        "@platforms//os:macos": [
+            "-Wl,-undefined,dynamic_lookup",
+            "-framework CoreFoundation",
+        ],
+        "//conditions:default": [
+            "-Wl,--version-script,$(location calcer.exports)",
+        ],
+    }),
+    additional_linker_inputs = ["calcer.exports"],
+    visibility = ["//visibility:public"],
+)
+
+# Static variant: same C API, compiled with CATBOOST_API_STATIC_LIB define.
+cc_library(
+    name = "catboostmodel_static_impl",
+    srcs = ["c_api.cpp"],
+    hdrs = ["c_api.h"],
+    defines = ["CATBOOST_API_STATIC_LIB"],
+    deps = [
+        "//catboost/libs/cat_feature",
+        "//catboost/libs/model",
+        "//catboost/libs/model:model_global",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/model_interface/static/BUILD.bazel
+++ b/catboost/libs/model_interface/static/BUILD.bazel
@@ -1,0 +1,15 @@
+# catboostmodel_static — fully self-contained static archive.
+#
+# Link this into your application to use CatBoost model inference with no
+# external dynamic library dependencies on the CatBoost runtime.
+
+cc_library(
+    name = "catboostmodel_static",
+    deps = [
+        "//catboost/libs/model_interface:catboostmodel_static_impl",
+        "//catboost/libs/model:model_global",
+        "//catboost/private/libs/embedding_features:embedding_features_global",
+        "//catboost/private/libs/text_features:text_features_global",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/libs/model_interface/static/lib/BUILD.bazel
+++ b/catboost/libs/model_interface/static/lib/BUILD.bazel
@@ -1,0 +1,9 @@
+# Deprecated: the static library target has been consolidated into
+# //catboost/libs/model_interface:catboostmodel_static_impl.
+# This package kept for directory structure parity with CMake.
+
+alias(
+    name = "catboostmodel_static_lib",
+    actual = "//catboost/libs/model_interface:catboostmodel_static_impl",
+    visibility = ["//visibility:public"],
+)

--- a/catboost/private/libs/ctr_description/BUILD.bazel
+++ b/catboost/private/libs/ctr_description/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "ctr_type_enum_serialization",
+    src = "ctr_type.h",
+    includes = ["catboost/private/libs/ctr_description/ctr_type.h"],
+)
+
+cc_library(
+    name = "ctr_description",
+    srcs = ["ctr_type.cpp"],
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":ctr_type_enum_serialization",
+        "//catboost/libs/helpers",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/private/libs/data_types/BUILD.bazel
+++ b/catboost/private/libs/data_types/BUILD.bazel
@@ -1,0 +1,11 @@
+cc_library(
+    name = "data_types",
+    srcs = [
+        "pair.cpp",
+        "query.cpp",
+        "text.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/private/libs/data_util/BUILD.bazel
+++ b/catboost/private/libs/data_util/BUILD.bazel
@@ -1,0 +1,11 @@
+cc_library(
+    name = "data_util",
+    srcs = [
+        "exists_checker.cpp",
+        "line_data_reader.cpp",
+        "path_with_scheme.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/private/libs/embedding_features/BUILD.bazel
+++ b/catboost/private/libs/embedding_features/BUILD.bazel
@@ -1,0 +1,50 @@
+load("//bazel:flatbuffers.bzl", "flatbuffers_library")
+
+flatbuffers_library(
+    name = "embedding_features_flatbuffers",
+    srcs = [
+        "flatbuffers/embedding_feature_calcers.fbs",
+        "flatbuffers/embedding_processing_collection.fbs",
+    ],
+    include_paths = [
+        "catboost/private/libs/embedding_features/flatbuffers",
+        ".",
+    ],
+    deps = [
+        "//contrib/libs/flatbuffers",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "embedding_features",
+    srcs = [
+        "embedding_calcers.cpp",
+        "embedding_feature_calcer.cpp",
+        "embedding_processing_collection.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":embedding_features_flatbuffers",
+        "//catboost/private/libs/text_features",
+        "//catboost/private/libs/text_processing",
+        "//contrib/libs/clapack",
+        "//contrib/libs/flatbuffers",
+        "//library/cpp/hnsw/index:hnsw_index",
+        "//library/cpp/online_hnsw/dense_vectors:dense_vectors",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Global library variant
+cc_library(
+    name = "embedding_features_global",
+    srcs = [
+        "knn.cpp",
+        "lda.cpp",
+    ],
+    deps = [":embedding_features"],
+    alwayslink = True,
+    visibility = ["//visibility:public"],
+)

--- a/catboost/private/libs/index_range/BUILD.bazel
+++ b/catboost/private/libs/index_range/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "index_range",
+    srcs = ["index_range.cpp"],
+    hdrs = ["index_range.h"],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/private/libs/options/BUILD.bazel
+++ b/catboost/private/libs/options/BUILD.bazel
@@ -1,0 +1,32 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "options_enums_serialization",
+    src = "enums.h",
+    includes = ["catboost/private/libs/options/enums.h"],
+)
+
+cc_library(
+    name = "options",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["**/*_ut*.cpp", "**/ut/**"],
+    ),
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":options_enums_serialization",
+        "//catboost/libs/column_description",
+        "//catboost/libs/helpers",
+        "//catboost/libs/logging",
+        "//catboost/private/libs/ctr_description",
+        "//catboost/private/libs/data_util",
+        "//library/cpp/getopt/small:getopt_small",
+        "//library/cpp/grid_creator",
+        "//library/cpp/json",
+        "//library/cpp/text_processing/dictionary:text_processing_dictionary",
+        "//library/cpp/text_processing/tokenizer:text_processing_tokenizer",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/catboost/private/libs/text_features/BUILD.bazel
+++ b/catboost/private/libs/text_features/BUILD.bazel
@@ -1,0 +1,54 @@
+load("//bazel:flatbuffers.bzl", "flatbuffers_library")
+
+flatbuffers_library(
+    name = "text_features_flatbuffers",
+    srcs = [
+        "flatbuffers/feature_calcers.fbs",
+        "flatbuffers/text_processing_collection.fbs",
+    ],
+    include_paths = [
+        "catboost/private/libs/text_features/flatbuffers",
+        ".",
+    ],
+    deps = [
+        "//contrib/libs/flatbuffers",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "text_features",
+    srcs = [
+        "feature_calcer.cpp",
+        "text_feature_calcers.cpp",
+        "text_processing_collection.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":text_features_flatbuffers",
+        "//catboost/libs/helpers",
+        "//catboost/private/libs/data_types",
+        "//catboost/private/libs/options",
+        "//catboost/private/libs/text_processing",
+        "//contrib/libs/clapack",
+        "//contrib/libs/flatbuffers",
+        "//library/cpp/threading/local_executor",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Global library variant with additional text feature calcer implementations
+cc_library(
+    name = "text_features_global",
+    srcs = [
+        "bm25.cpp",
+        "bow.cpp",
+        "naive_bayesian.cpp",
+    ],
+    deps = [
+        ":text_features",
+    ],
+    alwayslink = True,
+    visibility = ["//visibility:public"],
+)

--- a/catboost/private/libs/text_processing/BUILD.bazel
+++ b/catboost/private/libs/text_processing/BUILD.bazel
@@ -1,0 +1,21 @@
+cc_library(
+    name = "text_processing",
+    srcs = [
+        "dictionary.cpp",
+        "text_column_builder.cpp",
+        "text_dataset.cpp",
+        "text_digitizers.cpp",
+        "tokenizer.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//catboost/libs/helpers",
+        "//catboost/private/libs/data_types",
+        "//catboost/private/libs/options",
+        "//library/cpp/text_processing/dictionary:text_processing_dictionary",
+        "//library/cpp/text_processing/tokenizer:text_processing_tokenizer",
+        "//library/cpp/threading/local_executor",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/clapack/BUILD.bazel
+++ b/contrib/libs/clapack/BUILD.bazel
@@ -1,0 +1,19 @@
+# CLAPACK — C-language LAPACK for linear algebra (text/embedding features).
+
+cc_library(
+    name = "clapack",
+    srcs = glob(
+        [
+            "*.c",
+            "F2CLIBS/libf2c/*.c",
+        ],
+        exclude = [
+            "*_test*.c",
+            "test*.c",
+        ],
+    ),
+    hdrs = glob(["*.h", "F2CLIBS/libf2c/*.h", "include/*.h"]),
+    includes = [".", "include", "F2CLIBS/libf2c"],
+    copts = ["-Wno-everything"],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/crcutil/BUILD.bazel
+++ b/contrib/libs/crcutil/BUILD.bazel
@@ -1,0 +1,16 @@
+# CRCutil — hardware-accelerated CRC32c library.
+
+cc_library(
+    name = "crcutil",
+    srcs = [
+        "interface.cc",
+        "multiword_64_64_intrinsic_i386_mmx.cc",
+    ] + select({
+        "@platforms//cpu:x86_64": ["crc32c_sse4.cc"],
+        "//conditions:default": [],
+    }),
+    hdrs = glob(["*.h", "code/*.h", "interface/*.h"]),
+    includes = [".", "interface"],
+    copts = ["-Wno-everything"],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/cxxsupp/BUILD.bazel
+++ b/contrib/libs/cxxsupp/BUILD.bazel
@@ -1,0 +1,10 @@
+# contrib/libs/cxxsupp — Vendored C++ standard library override.
+#
+# In Yandex builds this provides a hermetic libc++/libc++abi. In a standard
+# Bazel build the system C++ toolchain already supplies the stdlib, so this
+# target is an empty interface library that just propagates compile flags.
+
+cc_library(
+    name = "cxxsupp",
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/double-conversion/BUILD.bazel
+++ b/contrib/libs/double-conversion/BUILD.bazel
@@ -1,0 +1,11 @@
+# Grisu3 double-to-string / string-to-double conversion library.
+
+cc_library(
+    name = "double-conversion",
+    srcs = glob(["double-conversion/*.cc"]),
+    hdrs = glob(["double-conversion/*.h"]),
+    # Expose headers as "double-conversion/<header>.h"
+    includes = ["."],
+    copts = ["-Wno-sign-compare"],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/flatbuffers/BUILD.bazel
+++ b/contrib/libs/flatbuffers/BUILD.bazel
@@ -1,0 +1,16 @@
+# FlatBuffers C++ runtime library (vendored).
+
+cc_library(
+    name = "flatbuffers",
+    srcs = [
+        "src/idl_gen_text.cpp",
+        "src/idl_parser.cpp",
+        "src/reflection.cpp",
+        "src/util.cpp",
+    ],
+    hdrs = glob(["include/flatbuffers/*.h"]),
+    includes = ["include"],
+    defines = ["FLATBUFFERS_LOCALE_INDEPENDENT=1"],
+    copts = ["-Wno-sign-compare"],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/flatbuffers/flatc/BUILD.bazel
+++ b/contrib/libs/flatbuffers/flatc/BUILD.bazel
@@ -1,0 +1,61 @@
+# flatc — FlatBuffers schema compiler (host tool).
+# Used as a build-time code generator for .fbs schema files.
+
+cc_binary(
+    name = "flatc",
+    srcs = [
+        # gRPC generator back-ends
+        "../grpc/src/compiler/cpp_generator.cc",
+        "../grpc/src/compiler/go_generator.cc",
+        "../grpc/src/compiler/java_generator.cc",
+        "../grpc/src/compiler/python_generator.cc",
+        "../grpc/src/compiler/swift_generator.cc",
+        "../grpc/src/compiler/ts_generator.cc",
+        # Core flatc sources
+        "annotated_binary_text_gen.cpp",
+        "bfbs_gen_lua.cpp",
+        "bfbs_gen_nim.cpp",
+        "binary_annotator.cpp",
+        "code_generators.cpp",
+        "file_binary_writer.cpp",
+        "file_name_saving_file_manager.cpp",
+        "file_writer.cpp",
+        "flatc.cpp",
+        "flatc_main.cpp",
+        "idl_gen_binary.cpp",
+        "idl_gen_cpp.cpp",
+        "idl_gen_cpp_yandex_maps_iter.cpp",
+        "idl_gen_csharp.cpp",
+        "idl_gen_dart.cpp",
+        "idl_gen_fbs.cpp",
+        "idl_gen_go.cpp",
+        "idl_gen_grpc.cpp",
+        "idl_gen_java.cpp",
+        "idl_gen_json_schema.cpp",
+        "idl_gen_kotlin.cpp",
+        "idl_gen_kotlin_kmp.cpp",
+        "idl_gen_lobster.cpp",
+        "idl_gen_php.cpp",
+        "idl_gen_python.cpp",
+        "idl_gen_rust.cpp",
+        "idl_gen_swift.cpp",
+        "idl_gen_text.cpp",
+        "idl_gen_ts.cpp",
+        "idl_parser.cpp",
+        "reflection.cpp",
+        "util.cpp",
+    ],
+    includes = [
+        "../grpc",
+        "../include",
+    ],
+    copts = [
+        "-DFLATBUFFERS_LOCALE_INDEPENDENT=1",
+        "-Wno-everything",
+    ],
+    linkopts = select({
+        "@platforms//os:macos": ["-framework CoreFoundation"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/fmath/BUILD.bazel
+++ b/contrib/libs/fmath/BUILD.bazel
@@ -1,0 +1,8 @@
+# fmath — fast math library (header-only, SIMD-accelerated exp/log).
+
+cc_library(
+    name = "fmath",
+    hdrs = ["fmath.hpp"],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/libc_compat/BUILD.bazel
+++ b/contrib/libs/libc_compat/BUILD.bazel
@@ -1,0 +1,21 @@
+# POSIX/C-library compatibility shims for platforms missing certain functions.
+
+cc_library(
+    name = "libc_compat",
+    srcs = [
+        "explicit_bzero.c",
+        "memrchr.c",
+        "reallocarray/reallocarray.c",
+        "string.c",
+    ],
+    hdrs = glob(
+        ["*.h", "include/*.h"],
+        allow_empty = True,
+    ),
+    includes = [".", "include"],
+    visibility = ["//visibility:public"],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-Wno-deprecated-declarations"],
+    }),
+)

--- a/contrib/libs/nayuki_md5/BUILD.bazel
+++ b/contrib/libs/nayuki_md5/BUILD.bazel
@@ -1,0 +1,13 @@
+# Nayuki MD5 implementation.
+
+cc_library(
+    name = "nayuki_md5",
+    srcs = ["md5.c"] + select({
+        "@platforms//cpu:x86_64": ["md5-fast-x8664.S"],
+        "//conditions:default": [],
+    }),
+    hdrs = ["md5.h"],
+    includes = ["."],
+    copts = ["-Wno-everything"],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/rapidjson/BUILD.bazel
+++ b/contrib/libs/rapidjson/BUILD.bazel
@@ -1,0 +1,8 @@
+# RapidJSON — header-only JSON parsing library.
+
+cc_library(
+    name = "rapidjson",
+    hdrs = glob(["include/rapidjson/**/*.h"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/tbb/BUILD.bazel
+++ b/contrib/libs/tbb/BUILD.bazel
@@ -1,0 +1,33 @@
+# Intel Threading Building Blocks (TBB) — vendored copy.
+
+cc_library(
+    name = "tbb",
+    srcs = glob(
+        [
+            "src/tbb/*.cpp",
+            "src/tbb/*.h",
+        ],
+        exclude = [
+            "src/tbb/*_test*",
+            "src/tbb/test*",
+        ],
+    ),
+    hdrs = glob([
+        "include/oneapi/**/*.h",
+        "include/tbb/**/*.h",
+    ]),
+    includes = ["include"],
+    copts = [
+        "-Wno-everything",
+        "-D__TBB_BUILD",
+        "-DTBB_USE_THREADING_TOOLS",
+        "-D_TBB_CPP0X",
+        "-DTBB_SUPPRESS_DEPRECATED_MESSAGES",
+        "-DTBB_PREVIEW_WAITING_FOR_WORKERS",
+    ],
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-lpthread", "-ldl"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/contrib/libs/zlib/BUILD.bazel
+++ b/contrib/libs/zlib/BUILD.bazel
@@ -1,0 +1,14 @@
+# zlib compression library (vendored).
+
+cc_library(
+    name = "zlib",
+    srcs = glob(["*.c"]),
+    hdrs = glob(["*.h", "include/*.h"]),
+    includes = ["include", "."],
+    defines = ["HAVE_HIDDEN"],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-Wno-implicit-function-declaration"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/binsaver/BUILD.bazel
+++ b/library/cpp/binsaver/BUILD.bazel
@@ -1,0 +1,16 @@
+cc_library(
+    name = "binsaver",
+    srcs = [
+        "bin_saver.cpp",
+        "blob_io.cpp",
+        "buffered_io.cpp",
+        "mem_io.cpp",
+        "util_stream_io.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//library/cpp/containers/2d_array",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/cache/BUILD.bazel
+++ b/library/cpp/cache/BUILD.bazel
@@ -1,0 +1,13 @@
+cc_library(
+    name = "cache",
+    srcs = [
+        "cache.cpp",
+        "thread_safe_cache.cpp",
+    ],
+    hdrs = [
+        "cache.h",
+        "thread_safe_cache.h",
+    ],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/colorizer/BUILD.bazel
+++ b/library/cpp/colorizer/BUILD.bazel
@@ -1,0 +1,14 @@
+cc_library(
+    name = "colorizer",
+    srcs = [
+        "colors.cpp",
+        "output.cpp",
+    ],
+    hdrs = [
+        "colors.h",
+        "fwd.h",
+        "output.h",
+    ],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/containers/2d_array/BUILD.bazel
+++ b/library/cpp/containers/2d_array/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "2d_array",
+    srcs = ["2d_array.cpp"],
+    hdrs = ["2d_array.h"],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/containers/dense_hash/BUILD.bazel
+++ b/library/cpp/containers/dense_hash/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "dense_hash",
+    srcs = ["dense_hash.cpp"],
+    hdrs = ["dense_hash.h"],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/containers/flat_hash/BUILD.bazel
+++ b/library/cpp/containers/flat_hash/BUILD.bazel
@@ -1,0 +1,22 @@
+cc_library(
+    name = "flat_hash",
+    srcs = [
+        "flat_hash.cpp",
+        "lib/concepts/container.cpp",
+        "lib/concepts/iterator.cpp",
+        "lib/concepts/size_fitter.cpp",
+        "lib/concepts/value_marker.cpp",
+        "lib/containers.cpp",
+        "lib/expanders.cpp",
+        "lib/iterator.cpp",
+        "lib/map.cpp",
+        "lib/probings.cpp",
+        "lib/set.cpp",
+        "lib/size_fitters.cpp",
+        "lib/table.cpp",
+        "lib/value_markers.cpp",
+    ],
+    hdrs = glob(["*.h", "lib/**/*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/cppparser/BUILD.bazel
+++ b/library/cpp/cppparser/BUILD.bazel
@@ -1,0 +1,12 @@
+# Simple C++ declaration parser used by the enum_parser tool.
+
+cc_library(
+    name = "cppparser",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["**/*_ut*.cpp"],
+    ),
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/dbg_output/BUILD.bazel
+++ b/library/cpp/dbg_output/BUILD.bazel
@@ -1,0 +1,14 @@
+cc_library(
+    name = "dbg_output",
+    srcs = [
+        "dump.cpp",
+        "dumpers.cpp",
+        "engine.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//library/cpp/colorizer",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/deprecated/atomic/BUILD.bazel
+++ b/library/cpp/deprecated/atomic/BUILD.bazel
@@ -1,0 +1,8 @@
+# Header-only shim for deprecated atomic APIs (wraps std::atomic).
+
+cc_library(
+    name = "atomic",
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/digest/crc32c/BUILD.bazel
+++ b/library/cpp/digest/crc32c/BUILD.bazel
@@ -1,0 +1,10 @@
+cc_library(
+    name = "crc32c",
+    srcs = ["crc32c.cpp"],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//contrib/libs/crcutil",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/digest/md5/BUILD.bazel
+++ b/library/cpp/digest/md5/BUILD.bazel
@@ -1,0 +1,11 @@
+cc_library(
+    name = "md5",
+    srcs = ["md5.cpp"],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//contrib/libs/nayuki_md5",
+        "//library/cpp/string_utils/base64",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/fast_exp/BUILD.bazel
+++ b/library/cpp/fast_exp/BUILD.bazel
@@ -1,0 +1,10 @@
+cc_library(
+    name = "fast_exp",
+    srcs = ["fast_exp.cpp"],
+    hdrs = ["fast_exp.h"],
+    deps = [
+        "//contrib/libs/fmath",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/getopt/small/BUILD.bazel
+++ b/library/cpp/getopt/small/BUILD.bazel
@@ -1,0 +1,27 @@
+cc_library(
+    name = "getopt_small",
+    srcs = [
+        "completer.cpp",
+        "completer_command.cpp",
+        "completion_generator.cpp",
+        "formatted_output.cpp",
+        "last_getopt.cpp",
+        "last_getopt_easy_setup.cpp",
+        "last_getopt_opt.cpp",
+        "last_getopt_opts.cpp",
+        "last_getopt_parser.cpp",
+        "last_getopt_parse_result.cpp",
+        "modchooser.cpp",
+        "opt.cpp",
+        "opt2.cpp",
+        "posix_getopt.cpp",
+        "wrap.cpp",
+        "ygetopt.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//library/cpp/colorizer",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/grid_creator/BUILD.bazel
+++ b/library/cpp/grid_creator/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "grid_creator_enum_serialization",
+    src = "binarization.h",
+    includes = ["library/cpp/grid_creator/binarization.h"],
+)
+
+cc_library(
+    name = "grid_creator",
+    srcs = ["binarization.cpp"],
+    hdrs = ["binarization.h"],
+    deps = [
+        ":grid_creator_enum_serialization",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/hnsw/index/BUILD.bazel
+++ b/library/cpp/hnsw/index/BUILD.bazel
@@ -1,0 +1,10 @@
+cc_library(
+    name = "hnsw_index",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["**/*_ut*.cpp"],
+    ),
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/json/BUILD.bazel
+++ b/library/cpp/json/BUILD.bazel
@@ -1,0 +1,19 @@
+cc_library(
+    name = "json",
+    srcs = [
+        "json_prettifier.cpp",
+        "json_reader.cpp",
+        "json_writer.cpp",
+        "rapidjson_helpers.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//contrib/libs/rapidjson",
+        "//library/cpp/json/common:json_common",
+        "//library/cpp/json/fast_sax:json_fast_sax",
+        "//library/cpp/json/writer:json_writer",
+        "//library/cpp/string_utils/relaxed_escaper",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/json/common/BUILD.bazel
+++ b/library/cpp/json/common/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "json_common",
+    srcs = ["defs.cpp"],
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/json/fast_sax/BUILD.bazel
+++ b/library/cpp/json/fast_sax/BUILD.bazel
@@ -1,0 +1,24 @@
+# Note: parser.rl6 must be compiled with Ragel to produce parser.cpp.
+# If parser.cpp is not pre-generated, install Ragel and uncomment the
+# genrule below.
+#
+# genrule(
+#     name = "fast_sax_parser_gen",
+#     srcs = ["parser.rl6"],
+#     outs = ["parser.cpp"],
+#     cmd = "ragel -CG2 -o $@ $(SRCS)",
+# )
+
+cc_library(
+    name = "json_fast_sax",
+    srcs = [
+        "parser.cpp",  # generated from parser.rl6 by Ragel
+        "unescape.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//library/cpp/json/common:json_common",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/json/writer/BUILD.bazel
+++ b/library/cpp/json/writer/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "json_value_enum_serialization",
+    src = "json_value.h",
+    includes = ["library/cpp/json/writer/json_value.h"],
+)
+
+cc_library(
+    name = "json_writer",
+    srcs = [
+        "json.cpp",
+        "json_value.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":json_value_enum_serialization",
+        "//library/cpp/json/common:json_common",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/langs/BUILD.bazel
+++ b/library/cpp/langs/BUILD.bazel
@@ -1,0 +1,14 @@
+cc_library(
+    name = "langs",
+    srcs = [
+        "generated/uniscripts.cpp",
+        "langs.cpp",
+        "scripts.cpp",
+    ],
+    hdrs = [
+        "langs.h",
+        "scripts.h",
+    ],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/logger/BUILD.bazel
+++ b/library/cpp/logger/BUILD.bazel
@@ -1,0 +1,36 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "logger_priority_enum_serialization",
+    src = "priority.h",
+    includes = ["library/cpp/logger/priority.h"],
+)
+
+cc_library(
+    name = "logger",
+    srcs = [
+        "backend.cpp",
+        "backend_creator.cpp",
+        "composite.cpp",
+        "element.cpp",
+        "file.cpp",
+        "filter.cpp",
+        "filter_creator.cpp",
+        "log.cpp",
+        "null.cpp",
+        "rotating_file.cpp",
+        "stream.cpp",
+        "sync_page_cache_file.cpp",
+        "system.cpp",
+        "thread.cpp",
+        "thread_creator.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":logger_priority_enum_serialization",
+        "//library/cpp/json",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/logger/global/BUILD.bazel
+++ b/library/cpp/logger/global/BUILD.bazel
@@ -1,0 +1,13 @@
+cc_library(
+    name = "logger_global",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["**/*_ut*.cpp"],
+    ),
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//library/cpp/logger",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/malloc/api/BUILD.bazel
+++ b/library/cpp/malloc/api/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "malloc_api",
+    srcs = ["malloc.cpp"],
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/object_factory/BUILD.bazel
+++ b/library/cpp/object_factory/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "object_factory",
+    srcs = ["object_factory.cpp"],
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/online_hnsw/dense_vectors/BUILD.bazel
+++ b/library/cpp/online_hnsw/dense_vectors/BUILD.bazel
@@ -1,0 +1,10 @@
+cc_library(
+    name = "dense_vectors",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["**/*_ut*.cpp"],
+    ),
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/string_utils/base64/BUILD.bazel
+++ b/library/cpp/string_utils/base64/BUILD.bazel
@@ -1,0 +1,11 @@
+# base64 encoding/decoding (may use SIMD back-ends; stubs provided here).
+# For full SIMD acceleration add the libs-base64-avx2, ssse3, neon32, etc.
+# sub-libraries from contrib/libs/base64 and list them in deps below.
+
+cc_library(
+    name = "base64",
+    srcs = ["base64.cpp"],
+    hdrs = ["base64.h"],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/string_utils/csv/BUILD.bazel
+++ b/library/cpp/string_utils/csv/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "csv",
+    srcs = ["csv.cpp"],
+    hdrs = ["csv.h"],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/string_utils/relaxed_escaper/BUILD.bazel
+++ b/library/cpp/string_utils/relaxed_escaper/BUILD.bazel
@@ -1,0 +1,7 @@
+cc_library(
+    name = "relaxed_escaper",
+    srcs = ["relaxed_escaper.cpp"],
+    hdrs = ["relaxed_escaper.h"],
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/text_processing/dictionary/BUILD.bazel
+++ b/library/cpp/text_processing/dictionary/BUILD.bazel
@@ -1,0 +1,26 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "dictionary_types_enum_serialization",
+    src = "types.h",
+    includes = ["library/cpp/text_processing/dictionary/types.h"],
+)
+
+cc_library(
+    name = "text_processing_dictionary",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["**/*_ut*.cpp"],
+    ),
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":dictionary_types_enum_serialization",
+        "//library/cpp/containers/flat_hash",
+        "//library/cpp/json",
+        "//library/cpp/text_processing/dictionary/idl:dictionary_idl",
+        "//library/cpp/threading/local_executor",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/text_processing/dictionary/idl/BUILD.bazel
+++ b/library/cpp/text_processing/dictionary/idl/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//bazel:flatbuffers.bzl", "flatbuffers_library")
+
+flatbuffers_library(
+    name = "dictionary_idl",
+    srcs = ["dictionary_meta_info.fbs"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/text_processing/tokenizer/BUILD.bazel
+++ b/library/cpp/text_processing/tokenizer/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//bazel:enum_serialization.bzl", "generate_enum_serialization")
+
+generate_enum_serialization(
+    name = "tokenizer_options_enum_serialization",
+    src = "options.h",
+    includes = ["library/cpp/text_processing/tokenizer/options.h"],
+)
+
+cc_library(
+    name = "text_processing_tokenizer",
+    srcs = [
+        "options.cpp",
+        "tokenizer.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        ":tokenizer_options_enum_serialization",
+        "//library/cpp/cache",
+        "//library/cpp/json",
+        "//library/cpp/langs",
+        "//library/cpp/object_factory",
+        "//library/cpp/tokenizer",
+        "//tools/enum_parser/enum_serialization_runtime",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/threading/future/BUILD.bazel
+++ b/library/cpp/threading/future/BUILD.bazel
@@ -1,0 +1,18 @@
+cc_library(
+    name = "future",
+    srcs = glob(
+        [
+            "*.cpp",
+            "core/*.cpp",
+            "wait/*.cpp",
+        ],
+        exclude = ["**/*_ut*.cpp", "**/ut/**", "**/benchmark/**", "**/perf/**"],
+    ),
+    hdrs = glob([
+        "*.h",
+        "core/*.h",
+        "wait/*.h",
+    ]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/threading/local_executor/BUILD.bazel
+++ b/library/cpp/threading/local_executor/BUILD.bazel
@@ -1,0 +1,14 @@
+cc_library(
+    name = "local_executor",
+    srcs = [
+        "local_executor.cpp",
+        "tbb_local_executor.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//contrib/libs/tbb",
+        "//library/cpp/threading/future",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/library/cpp/tokenizer/BUILD.bazel
+++ b/library/cpp/tokenizer/BUILD.bazel
@@ -1,0 +1,13 @@
+# Note: .rl and .rl6 files need to be compiled with Ragel.
+# If the generated .cpp files are not pre-committed, install Ragel to build them.
+
+cc_library(
+    name = "tokenizer",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["**/*_ut*.cpp"],
+    ),
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/enum_parser/enum_parser/BUILD.bazel
+++ b/tools/enum_parser/enum_parser/BUILD.bazel
@@ -1,0 +1,16 @@
+# enum_parser — host binary that generates enum serialization .cpp files.
+# This tool is used at build time via the generate_enum_serialization() macro.
+
+cc_binary(
+    name = "enum_parser",
+    srcs = [
+        "main.cpp",
+        "stdlib_deps.h",
+    ],
+    deps = [
+        "//library/cpp/getopt/small:getopt_small",
+        "//tools/enum_parser/parse_enum",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/enum_parser/enum_serialization_runtime/BUILD.bazel
+++ b/tools/enum_parser/enum_serialization_runtime/BUILD.bazel
@@ -1,0 +1,13 @@
+# Runtime support library for enum serialization (ToString/FromString/Out).
+
+cc_library(
+    name = "enum_serialization_runtime",
+    srcs = [
+        "dispatch_methods.cpp",
+        "enum_runtime.cpp",
+        "ordered_pairs.cpp",
+    ],
+    hdrs = glob(["*.h"]),
+    deps = ["//util"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/enum_parser/parse_enum/BUILD.bazel
+++ b/tools/enum_parser/parse_enum/BUILD.bazel
@@ -1,0 +1,12 @@
+# parse_enum — library that implements the enum scanning/parsing logic.
+
+cc_library(
+    name = "parse_enum",
+    srcs = ["parse_enum.cpp"],
+    hdrs = ["parse_enum.h"],
+    deps = [
+        "//library/cpp/cppparser",
+        "//util",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,0 +1,80 @@
+# yutil — Yandex core utility library.
+#
+# This is a large monolithic library covering: string/stream I/O, containers,
+# memory allocators, threading primitives, platform abstractions, datetime,
+# digests, random number generation, and network utilities.
+#
+# Note: util/datetime/parser.rl6 must be processed by Ragel to produce
+# parser.cpp.  If parser.cpp is not pre-generated in the source tree, install
+# Ragel and uncomment the genrule below.
+
+# --------------------------------------------------------------------------
+# Ragel code generation (uncomment if parser.cpp is not pre-generated)
+# --------------------------------------------------------------------------
+# genrule(
+#     name = "datetime_parser_gen",
+#     srcs = ["datetime/parser.rl6"],
+#     outs = ["datetime/parser.cpp"],
+#     cmd = "ragel -CG2 -o $@ $(SRCS)",
+# )
+# --------------------------------------------------------------------------
+
+cc_library(
+    name = "yutil",
+    srcs = glob(
+        [
+            "charset/*.cpp",
+            "datetime/*.cpp",
+            "digest/*.cpp",
+            "folder/*.cpp",
+            "generic/*.cpp",
+            "memory/*.cpp",
+            "network/*.cpp",
+            "random/*.cpp",
+            "stream/*.cpp",
+            "string/*.cpp",
+            "system/*.cpp",
+            "thread/*.cpp",
+        ],
+        exclude = [
+            "**/*_ut*.cpp",
+            "**/*_ut_*.cpp",
+            "**/ut/**",
+            "**/benchmark/**",
+        ],
+    ),
+    hdrs = glob([
+        "*.h",
+        "charset/*.h",
+        "datetime/*.h",
+        "digest/*.h",
+        "folder/*.h",
+        "generic/*.h",
+        "memory/*.h",
+        "network/*.h",
+        "random/*.h",
+        "stream/*.h",
+        "string/*.h",
+        "system/*.h",
+        "thread/*.h",
+    ]),
+    copts = [
+        "-Wno-narrowing",
+        "-Wno-deprecated-declarations",
+    ],
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "@platforms//os:macos": [],
+        "//conditions:default": [
+            "-lpthread",
+            "-ldl",
+            "-lrt",
+        ],
+    }),
+    deps = [
+        "//contrib/libs/double-conversion",
+        "//contrib/libs/libc_compat",
+        "//contrib/libs/zlib",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Creates a complete set of BUILD.bazel files, a WORKSPACE, .bazelrc, and custom Starlark macros (bazel/flatbuffers.bzl, bazel/enum_serialization.bzl) that replicate the CMake/YaTool dependency graph for the CatBoost C++ inference path.

Primary build targets:
  //:catboostmodel_static  – fully self-contained static archive (C API)
  //:catboostmodel         – shared library (.so/.dylib/.dll)

Dependency coverage (68 BUILD.bazel files):
  contrib/libs – double-conversion, zlib, flatbuffers (+ flatc binary),
                 rapidjson, crcutil, nayuki_md5, fmath, tbb, clapack,
                 cxxsupp, libc_compat
  util/         – yutil (all charset/datetime/digest/generic/memory/
                  network/random/stream/string/system/thread modules)
  library/cpp/  – binsaver, cache, colorizer, containers, cppparser,
                  dbg_output, deprecated/atomic, digest, fast_exp,
                  getopt/small, grid_creator, hnsw/index, json (+ sub-
                  libs), langs, logger (+ global), malloc/api,
                  object_factory, online_hnsw/dense_vectors,
                  string_utils, text_processing, threading, tokenizer
  tools/        – enum_parser binary + parse_enum + runtime support
  catboost/     – cat_feature, column_description, helpers, logging,
                  model (+ flatbuffers codegen), model_interface,
                  private/{ctr_description,data_types,data_util,
                  embedding_features,index_range,options,
                  text_features,text_processing}

Build configuration (.bazelrc):
  – C++20, workspace-root-relative includes (--copt=-I.)
  – Silence all warnings in vendored contrib/ code

Notes:
  – Ragel-generated files (util/datetime/parser.cpp,
    library/cpp/json/fast_sax/parser.cpp, library/cpp/tokenizer/*.cpp)
    must either be pre-generated in the source tree or Ragel installed.
    Commented-out genrules are provided where applicable.
  – FlatBuffers .fbs codegen runs the vendored flatc binary at build time
    via the flatbuffers_library() macro.
  – Enum serialization codegen runs the vendored enum_parser binary via
    the generate_enum_serialization() macro.

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
