### PR TITLE
update LightGBM links

### DIFF
--- a/catboost/benchmarks/kaggle/rossmann-store-sales/README.md
+++ b/catboost/benchmarks/kaggle/rossmann-store-sales/README.md
@@ -114,7 +114,7 @@ GPU - 2x nVidia GeForce 1080 Ti.
         <td>lightgbm with specifying cat features</td>
         <td>n/a</td>
         <td>n/a</td>
-        <td><font color="red">Failed: [LightGBM] [Fatal] bin size 1093 cannot run on GPU</font>, see <a href="https://github.com/Microsoft/LightGBM/issues/1116">https://github.com/Microsoft/LightGBM/issues/1116</a> </td>
+        <td><font color="red">Failed: [LightGBM] [Fatal] bin size 1093 cannot run on GPU</font>, see <a href="https://github.com/lightgbm-org/LightGBM/issues/1116">https://github.com/lightgbm-org/LightGBM/issues/1116</a> </td>
     </tr>
     <tr>
         <td>xgboost in 'gpu-exact' mode</td>

--- a/catboost/benchmarks/quality_benchmarks/install/install.sh
+++ b/catboost/benchmarks/quality_benchmarks/install/install.sh
@@ -19,7 +19,7 @@ tar -xvzf openmpi-2.1.0.tar.gz && cd openmpi-2.1.0 && ./configure --prefix="/hom
 cd ../ && rm openmpi-2.1.0.tar.gz && rm -rf openmpi-2.1.0
 
 # LightGBM
-git clone --recursive https://github.com/Microsoft/LightGBM
+git clone --recursive https://github.com/lightgbm-org/LightGBM
 cd LightGBM
 git checkout 60c77487c15a69c9451be80fa9b15e987559a995
 mkdir build && cd build && cmake -DUSE_MPI=ON .. && make && cd ../python-package/ && python setup.py install


### PR DESCRIPTION
LightGBM has moved out of `Microsoft/` to its own organization: https://github.com/lightgbm-org/LightGBM/issues/7187

This updates links in this project to reflect that.