### PR TITLE
Fix sklearn.base.clone for CatBoost estimators with mutable params

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1814,6 +1814,12 @@ class _CatBoostBase(object):
         model.__setstate__(state)
         return model
 
+    def __sklearn_clone__(self):
+        new_obj = type(self)(**{k: deepcopy(v) for k, v in self.get_params(deep=False).items()})
+        if hasattr(self, "_metadata_request"):
+            new_obj._metadata_request = deepcopy(self._metadata_request)
+        return new_obj
+
     def __eq__(self, other):
         return self._is_comparable_to(other) and self._object == other._object
 

--- a/catboost/python-package/ut/medium/test_with_sklearn.py
+++ b/catboost/python-package/ut/medium/test_with_sklearn.py
@@ -338,3 +338,45 @@ def test_sklearn_tags_nan_mode_forbidden(task_type):
     else:
         tags = model._get_tags()
         assert tags['allow_nan'] is False
+
+
+@pytest.mark.parametrize(
+    'estimator_cls',
+    [CatBoostClassifier, CatBoostRegressor, CatBoostRanker],
+    ids=['Classifier', 'Regressor', 'Ranker'],
+)
+def test_clone_with_mutable_params(estimator_cls):
+    for kwargs in (
+        {'cat_features': [0, 1]},
+        {'text_features': [0]},
+        {'embedding_features': [0]},
+    ):
+        original = estimator_cls(iterations=2, verbose=False, **kwargs)
+        cloned = sklearn.base.clone(original)
+        assert type(cloned) is estimator_cls
+        for key, value in kwargs.items():
+            assert cloned.get_params(deep=False)[key] == value
+
+
+def test_clone_without_mutable_params():
+    for cls in (CatBoostClassifier, CatBoostRegressor, CatBoostRanker):
+        sklearn.base.clone(cls(iterations=2, verbose=False))
+
+
+@pytest.mark.skipif(
+    scikit_learn_version < (1, 3),
+    reason="metadata routing requires scikit-learn >= 1.3"
+)
+def test_clone_preserves_metadata_routing_request():
+    original = CatBoostRanker(iterations=2, verbose=False).set_fit_request(group_id=True)
+    cloned = sklearn.base.clone(original)
+    assert hasattr(cloned, '_metadata_request')
+    assert repr(original._metadata_request) == repr(cloned._metadata_request)
+
+
+def test_cross_val_score_with_cat_features():
+    from sklearn.model_selection import cross_val_score
+
+    X, y = make_classification(60, 5, random_state=0)
+    estimator = CatBoostClassifier(cat_features=[0], iterations=2, verbose=False)
+    cross_val_score(estimator, X, y, cv=3)

--- a/catboost/python-package/ut/medium/test_with_sklearn.py
+++ b/catboost/python-package/ut/medium/test_with_sklearn.py
@@ -363,18 +363,6 @@ def test_clone_without_mutable_params():
         sklearn.base.clone(cls(iterations=2, verbose=False))
 
 
-@pytest.mark.skipif(
-    scikit_learn_version < (1, 3),
-    reason="metadata routing requires scikit-learn >= 1.3"
-)
-def test_clone_preserves_metadata_routing_request():
-    with sklearn.config_context(enable_metadata_routing=True):
-        original = CatBoostRanker(iterations=2, verbose=False).set_fit_request(group_id=True)
-        cloned = sklearn.base.clone(original)
-        assert hasattr(cloned, '_metadata_request')
-        assert repr(original._metadata_request) == repr(cloned._metadata_request)
-
-
 def test_cross_val_score_with_cat_features():
     from sklearn.model_selection import cross_val_score
 

--- a/catboost/python-package/ut/medium/test_with_sklearn.py
+++ b/catboost/python-package/ut/medium/test_with_sklearn.py
@@ -368,15 +368,18 @@ def test_clone_without_mutable_params():
     reason="metadata routing requires scikit-learn >= 1.3"
 )
 def test_clone_preserves_metadata_routing_request():
-    original = CatBoostRanker(iterations=2, verbose=False).set_fit_request(group_id=True)
-    cloned = sklearn.base.clone(original)
-    assert hasattr(cloned, '_metadata_request')
-    assert repr(original._metadata_request) == repr(cloned._metadata_request)
+    with sklearn.config_context(enable_metadata_routing=True):
+        original = CatBoostRanker(iterations=2, verbose=False).set_fit_request(group_id=True)
+        cloned = sklearn.base.clone(original)
+        assert hasattr(cloned, '_metadata_request')
+        assert repr(original._metadata_request) == repr(cloned._metadata_request)
 
 
 def test_cross_val_score_with_cat_features():
     from sklearn.model_selection import cross_val_score
 
     X, y = make_classification(60, 5, random_state=0)
+    X = pd.DataFrame(X)
+    X[0] = (X[0] > 0).astype(int)
     estimator = CatBoostClassifier(cat_features=[0], iterations=2, verbose=False)
     cross_val_score(estimator, X, y, cv=3)


### PR DESCRIPTION
get_params() returns deepcopy(self._init_params), so sklearn.base.clone's default `is`-identity round-trip check fails for any estimator constructed with a mutable param (cat_features, text_features, embedding_features, ...). This broke cross_val_score, GridSearchCV, Optuna, and any other tool relying on clone().

Add __sklearn_clone__ to _CatBoostBase (sklearn >= 1.3 hook) so cloning bypasses the identity check while still producing an independent estimator. Also preserve _metadata_request so set_fit_request(group_id=True) on CatBoostRanker survives the clone (otherwise sklearn's metadata routing raises UnsetMetadataPassedError inside cross_val_score / pipelines).

Fixes #3078 
