### PR TITLE
Fix unchecked Skip() return values in zero-copy model loading paths

### DIFF
--- a/catboost/libs/model/ctr_value_table.cpp
+++ b/catboost/libs/model/ctr_value_table.cpp
@@ -73,7 +73,8 @@ void TCtrValueTable::LoadSolid(void* buf, size_t length) {
 void TCtrValueTable::LoadThin(TMemoryInput* in) {
     auto len = LoadSize(in);
     auto ptr = in->Buf();
-    in->Skip(len);
+    const size_t skipped = in->Skip(len);
+    CB_ENSURE(skipped == len, "Failed to read CTR value table in zero-copy model loading");
 
     using namespace  flatbuffers;
     Impl = TThinTable();

--- a/catboost/libs/model/model.cpp
+++ b/catboost/libs/model/model.cpp
@@ -1238,7 +1238,8 @@ void TFullModel::InitNonOwning(const void* binaryBuffer, size_t binarySize) {
 
     size_t coreSize = ::LoadSize(&in);
     const ui8* fbPtr = reinterpret_cast<const ui8*>(in.Buf());
-    in.Skip(coreSize);
+    const size_t skippedCore = in.Skip(coreSize);
+    CB_ENSURE(skippedCore == coreSize, "Failed to skip core data in zero-copy model loading");
 
     {
         flatbuffers::Verifier verifier(fbPtr, coreSize, 64 /* max depth */, 256000000 /* max tables */);

--- a/catboost/private/libs/embedding_features/embedding_processing_collection.cpp
+++ b/catboost/private/libs/embedding_features/embedding_processing_collection.cpp
@@ -318,7 +318,8 @@ namespace NCB {
             );
 
             auto collectionPart = flatbuffers::GetRoot<NCatBoostFbs::NEmbeddings::TCollectionPart>(in->Buf());
-            in->Skip(headerSize);
+            const size_t skippedHeader = in->Skip(headerSize);
+            CB_ENSURE(skippedHeader == headerSize, "Failed to read embedding collection part");
 
             const auto partId = GuidFromFbs(collectionPart->Id());
 

--- a/catboost/private/libs/text_features/text_processing_collection.cpp
+++ b/catboost/private/libs/text_features/text_processing_collection.cpp
@@ -348,7 +348,8 @@ namespace NCB {
             );
 
             auto collectionPart = flatbuffers::GetRoot<NCatBoostFbs::TCollectionPart>(in->Buf());
-            in->Skip(headerSize);
+            const size_t skipped = in->Skip(headerSize);
+            CB_ENSURE(skipped == headerSize, "Failed to read text processing collection part");
 
             const auto partId = GuidFromFbs(collectionPart->Id());
 


### PR DESCRIPTION
IInputStream::Skip() may return fewer bytes than requested. Several zero-copy LoadNonOwning paths ignored Skip() return values, allowing a malformed model file with a forged size field to advance the stream past its buffer. Subsequent reads from the exhausted stream access uninitialized memory.

**Files changed (4 files, +8/-4 lines):**

- `TFullModel::InitNonOwning` (model.cpp) — check `in.Skip(coreSize)` return
- `TCtrValueTable::LoadThin` (ctr_value_table.cpp) — check `in->Skip(len)` return
- `TTextProcessingCollection::LoadNonOwning` — defense-in-depth Skip check
- `TEmbeddingProcessingCollection::LoadNonOwning` — defense-in-depth Skip check

The default (owning) `TFullModel::Load` path is protected by `LoadOrFail`. The zero-copy `InitNonOwning` / `ReadZeroCopyModel` path (used by C API and JVM bindings) was vulnerable.

All fixes use the same pattern as existing error handling in the codebase (`CB_ENSURE` with a descriptive message).