### PR TITLE
added support of memoryview for blob arg of load_model

### DIFF
--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -5829,10 +5829,10 @@ cdef class _CatBoost:
         cdef bytes py_serialized_model_str = c_serialized_model_string[:tstr.size()]
         return py_serialized_model_str
 
-    cpdef _deserialize_model(self, serialized_model_str):
+    cpdef _deserialize_model(self, serialized_model_blob):
         cdef const unsigned char[::1] buf
-        buf = serialized_model_str
-        self.model_blob = serialized_model_str
+        buf = serialized_model_blob
+        self.model_blob = serialized_model_blob
         cdef TFullModel tmp_model = ReadZeroCopyModel(<char*>&buf[0], len(buf))
         self.__model.Swap(tmp_model)
         self.__metrics_history = GetTrainingMetrics(self.__model[0])

--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -5830,8 +5830,10 @@ cdef class _CatBoost:
         return py_serialized_model_str
 
     cpdef _deserialize_model(self, serialized_model_str):
+        cdef const unsigned char[::1] buf
+        buf = serialized_model_str
         self.model_blob = serialized_model_str
-        cdef TFullModel tmp_model = ReadZeroCopyModel(<char*>serialized_model_str, len(serialized_model_str))
+        cdef TFullModel tmp_model = ReadZeroCopyModel(<char*>&buf[0], len(buf))
         self.__model.Swap(tmp_model)
         self.__metrics_history = GetTrainingMetrics(self.__model[0])
 

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1976,7 +1976,7 @@ class _CatBoostBase(object):
         return self._object._serialize_model()
 
     def _deserialize_model(self, dump_model_str):
-        assert isinstance(dump_model_str, bytes), "Not bytes passed as argument"
+        assert isinstance(dump_model_str, (bytes, memoryview)), "Not bytes passed as argument"
         self._object._deserialize_model(dump_model_str)
 
     def _load_from_string(self, dump_model_str):

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1790,7 +1790,7 @@ class _CatBoostBase(object):
         if '_init_params' not in dict(self.__dict__.items()):
             self._init_params = {}
         if '__model' in state:
-            self._load_from_string(state['__model'])
+            self._load_from_blob(state['__model'])
             del state['__model']
         if '_test_eval' in state:
             self._set_test_evals([state['_test_eval']])
@@ -1975,12 +1975,12 @@ class _CatBoostBase(object):
     def _serialize_model(self):
         return self._object._serialize_model()
 
-    def _deserialize_model(self, dump_model_str):
-        assert isinstance(dump_model_str, (bytes, memoryview)), "Not bytes passed as argument"
-        self._object._deserialize_model(dump_model_str)
+    def _deserialize_model(self, blob):
+        assert isinstance(blob, (bytes, memoryview)), f"Unsupported 'blob' type '{type(blob)}', expected 'bytes' or 'memoryview'"
+        self._object._deserialize_model(blob)
 
-    def _load_from_string(self, dump_model_str):
-        self._deserialize_model(dump_model_str)
+    def _load_from_blob(self, blob):
+        self._deserialize_model(blob)
         self._set_trained_model_attributes()
 
     def _load_from_stream(self, stream):
@@ -3782,7 +3782,7 @@ class CatBoost(_CatBoostBase):
         elif stream is not None:
             self._load_from_stream(stream)
         elif blob is not None:
-            self._load_from_string(blob)
+            self._load_from_blob(blob)
         return self
 
     def get_param(self, key):

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -1372,10 +1372,16 @@ def test_save_load_equality(task_type):
         cb_blob.load_model(blob=open(output_model_path, 'rb').read())
         check_equality(model, cb_blob)
 
+    def check_load_from_memoryview(model):
+        cb_blob = CatBoost()
+        cb_blob.load_model(blob=memoryview(open(output_model_path, 'rb').read()))
+        check_equality(model, cb_blob)
+
     def fill_check_model(params, train_file, test_file, cd_file):
         model, _ = fit_from_file(params, train_file, test_file, cd_file)
         model.save_model(fname=output_model_path)
         check_load_from_string(model)
+        check_load_from_memoryview(model)
         check_load_from_stream(model)
 
     fill_check_model({'iterations': 10, 'task_type': task_type, 'gpu_ram_part': TEST_GPU_RAM_PART, 'devices': '0'}, TRAIN_FILE, TEST_FILE, CD_FILE)


### PR DESCRIPTION
Currently the blob arg of load_model does not support memoryview. This makes it impossible to load models from mmaped files without copying them. In this PR I fix this.