### PR TITLE
Fix default prediction link function and parameter sync for stream/blob loaded models

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -6345,9 +6345,7 @@ class CatBoostRegressor(CatBoost):
                                 "RMSE, MultiRMSE, SurvivalAft, MAE, Quantile, LogLinQuantile, Poisson, MAPE, Lq, RMSPE or a custom objective object".format(loss_function))
 
     def _get_default_prediction_type(self):
-        # TODO(ilyzhin) change on get_all_params after MLTOOLS-4758
-        params = self._get_canonized_params()
-        loss_function = params.get('loss_function')
+        loss_function = self._object._get_loss_function_name() if self.is_fitted() else None
         if loss_function and isinstance(loss_function, str):
             if loss_function.startswith('Poisson') or loss_function.startswith('Tweedie'):
                 return 'Exponent'

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -1843,6 +1843,12 @@ class _CatBoostBase(object):
         setattr(self, '_tree_count', self._object._get_tree_count())
         setattr(self, '_n_features_in', self._object._get_n_features_in())
 
+    def _sync_params_from_model(self):
+        self._init_params = {}
+        for key, value in iteritems(self._get_params_from_model_updated_with_init_params()):
+            self._init_params[key] = value
+        self._canonized_params = None
+
     def _train(self, train_pool, test_pool, params, allow_clear_pool, init_model):
         self._object._train(train_pool, test_pool, params, allow_clear_pool, init_model._object if init_model else None)
         self._set_trained_model_attributes()
@@ -1965,12 +1971,9 @@ class _CatBoostBase(object):
     def _load_model(self, model_file, format):
         if not isinstance(model_file, PATH_TYPES):
             raise CatBoostError("Invalid fname type={}: must be str or os.PathLike.".format(type(model_file)))
-        self._init_params = {}
         self._object._load_model(model_file, format)
         self._set_trained_model_attributes()
-        for key, value in iteritems(self._get_params_from_model_updated_with_init_params()):
-            self._init_params[key] = value
-        self._canonized_params = None
+        self._sync_params_from_model()
 
     def _serialize_model(self):
         return self._object._serialize_model()
@@ -1982,10 +1985,12 @@ class _CatBoostBase(object):
     def _load_from_string(self, dump_model_str):
         self._deserialize_model(dump_model_str)
         self._set_trained_model_attributes()
+        self._sync_params_from_model()
 
     def _load_from_stream(self, stream):
         self._object._load_from_stream(stream)
         self._set_trained_model_attributes()
+        self._sync_params_from_model()
 
     def _sum_models(self, models_base, weights=None, ctr_merge_policy='IntersectingCountersAverage'):
         if weights is None:


### PR DESCRIPTION
**Fixed default prediction link function and parameter sync for stream/blob loaded models**

from [ISSUE #3103](https://github.com/catboost/catboost/issues/3103#issue-4555673322)

Changes Made:

**Change 1:**
Implement BUG change: `# TODO(ilyzhin) change on get_all_params after MLTOOLS-4758`
with code: 
```cpp
 loss_function = self._object._get_loss_function_name() if self.is_fitted() else None
```
now allows the model to directly refer the C++ model engine avoiding the Temporary Python Dictionary preventing parameter override

**Change 2:**
Implemented Parameter Sync issue

By implementing immediate copying of tthe configuration parameters to python dictionary when loaded from memory.
we make sure that ``get_param('loss_function')`` always returns `Poisson` rather than `NONE` 

with code changes at: 
**L1846**:
```
      def _sync_params_from_model(self):
        self._init_params = {}
        for key, value in iteritems(self._get_params_from_model_updated_with_init_params()):
            self._init_params[key] = value
        self._canonized_params = None
```


L (**1976, 1988, 1993**):  `self._sync_params_from_model()`
this change push the model to sync all params from model at each stage to ensure accurate config params


**ALL TEST CASES and C.MAKE reviews PASSED**