### PR TITLE
fix: add __sklearn_clone__ method for sklearn compatibility

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -2568,6 +2568,30 @@ class CatBoost(_CatBoostBase):
         """
         super(CatBoost, self).__init__(params)
 
+    def __sklearn_clone__(self):
+        """
+        Custom clone method for scikit-learn compatibility.
+
+        This method is called by sklearn.base.clone() instead of the default
+        identity-checking logic. It handles mutable parameters like cat_features,
+        text_features, and embedding_features correctly by using deepcopy.
+
+        Returns
+        -------
+        result : CatBoost
+            A new instance with the same parameters.
+        """
+        klass = self.__class__
+        params = self.get_params(deep=False)
+        new_params = {k: deepcopy(v) for k, v in params.items()}
+        new_obj = klass(**new_params)
+
+        # Preserve sklearn metadata routing requests (set_fit_request, set_score_request, etc.)
+        if hasattr(self, "_metadata_request"):
+            new_obj._metadata_request = deepcopy(self._metadata_request)
+
+        return new_obj
+
     def _dataset_train_eval_split(self, train_pool, params, save_eval_pool):
         """
         returns:


### PR DESCRIPTION
## Description

Fixes #3078: `sklearn.base.clone()` fails with `RuntimeError` for CatBoost >= 1.2.10 when mutable params are set.

## Root Cause

In CatBoost 1.2.10, `get_params()` was changed to return `deepcopy(self._init_params)` to prevent mutation of internal state. However, `sklearn.base.clone()` uses **object identity** (`is`) to verify that parameters are preserved after round-tripping through `get_params() → constructor → get_params()`. The `deepcopy` breaks this identity check.

## Solution

Added `__sklearn_clone__` method to the `CatBoost` class. This is sklearn's official extension point (available since scikit-learn 1.3) — when defined, `clone()` calls it instead of the default identity-checking logic.

### Key Features:
- Handles all mutable parameters (`cat_features`, `text_features`, `embedding_features`)
- Preserves sklearn metadata routing requests (`set_fit_request`, `set_score_request`, etc.)
- Minimal change - does not require modifications to `__init__`, `get_params`, or `set_params`
- Compatible with scikit-learn >= 1.3

## Testing

```python
from sklearn.base import clone
from catboost import CatBoostClassifier, CatBoostRegressor, CatBoostRanker

# These should all work now:
clone(CatBoostClassifier())
clone(CatBoostClassifier(cat_features=[0, 1]))
clone(CatBoostRegressor(cat_features=[0, 1]))
clone(CatBoostRanker(cat_features=[0, 1]))
```

## Related Issues

- #3078: sklearn.base.clone() fails with RuntimeError for CatBoost >= 1.2.10
- #2991: Related to the original change that introduced deepcopy in get_params