### PR TITLE
Improve error message for wrong training parameter type

### DIFF
--- a/catboost/private/libs/options/json_helper.h
+++ b/catboost/private/libs/options/json_helper.h
@@ -19,6 +19,7 @@
 #include <util/generic/maybe.h>
 #include <util/string/cast.h>
 #include <util/system/compiler.h>
+#include <util/system/type_name.h>
 
 
 
@@ -38,7 +39,8 @@ public:
                 TJsonFieldHelper<T>::Read(srcValue, &dst->Value);
                 dst->IsSetFlag = true;
             } catch (NJson::TJsonException) {
-                ythrow TCatBoostException() << "Can't parse parameter \"" << key << "\" with value: " << srcValue;
+                ythrow TCatBoostException() << "Can't parse parameter \"" << key << "\" with value: " << srcValue
+                                            << " as " << TypeName<T>();
             }
             return true;
         } else {

--- a/catboost/private/libs/options/ut/json_helper_ut.cpp
+++ b/catboost/private/libs/options/ut/json_helper_ut.cpp
@@ -158,6 +158,27 @@ Y_UNIT_TEST_SUITE(TJsonHelperTest) {
         SaveFields(&tree2, option1, option2);
         UNIT_ASSERT_VALUES_EQUAL(ToString<NJson::TJsonValue>(tree2), "{\"option_1\":102}");
     }
+
+    Y_UNIT_TEST(TestWrongTypeErrorMessage) {
+        // https://github.com/catboost/catboost/issues/872
+        // Passing a floating point value for an integer parameter must produce an error message
+        // that mentions both the failing value and the expected type.
+        TStringBuf jsonStr = ""
+                             "{\n"
+                             "  \"leaf_estimation_iterations\": 86.85434834\n"
+                             "}"
+                             "";
+
+        NJson::TJsonValue tree;
+        NJson::ReadJsonTree(jsonStr, &tree);
+        TOption<int> option("leaf_estimation_iterations", 1);
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            TJsonFieldHelper<decltype(option)>::Read(tree, &option),
+            TCatBoostException,
+            "Can't parse parameter \"leaf_estimation_iterations\" with value: 86.85434834 as int");
+    }
+
         Y_UNIT_TEST(TestPlainAndReversePlainSerialization) {
             TString jsonPlain = ""
                 "{\n"


### PR DESCRIPTION
## Improve error message for wrong training parameter type

Fixes #872

### Problem

When a training parameter gets a value of the wrong type, the error doesn't say
which type was expected. Passing a float for the integer parameter
`leaf_estimation_iterations` (an easy mistake when a hyperopt search space is set
up wrong) gives:

```
_catboost.CatBoostError: catboost/libs/options/json_helper.h:153:
Can't parse parameter "leaf_estimation_iterations" with value: 86.85434834
```

Nothing tells the user the value had to be an integer.

### Change

The parse-error path in `TJsonFieldHelper<TOption<T>>::Read` now adds the expected
type, which is already known at compile time. The same input now produces:

```
Can't parse parameter "leaf_estimation_iterations" with value: 86.85434834 as int
```

The edit is small: `<< " as " << TypeName<T>()` on the existing throw, plus the
`<util/system/type_name.h>` include. It runs for every option, so any wrong-typed
parameter reports the type it expected.

### Tests

Added `TJsonHelperTest::TestWrongTypeErrorMessage`, which feeds a float to an `int`
option and checks the message contains the expected type.

---

Before submitting a pull request, please do the following steps:

1. [x] Read instructions for contributors.
2. [x] Made sure the code builds. I built the full `catboost` CLI app from source with clang 18.
3. [x] Added a test for the new behaviour in `json_helper_ut.cpp`.
4. [x] Ran existing tests. The `json_options_ut` suite passes 15 of 15 with no regressions.