### PR TITLE
Improve wrong type error coverage for TOption parsing

### DIFF
--- a/catboost/private/libs/options/json_helper.h
+++ b/catboost/private/libs/options/json_helper.h
@@ -19,6 +19,7 @@
 #include <util/generic/maybe.h>
 #include <util/string/cast.h>
 #include <util/system/compiler.h>
+#include <util/system/type_name.h>
 
 
 
@@ -38,7 +39,8 @@ public:
                 TJsonFieldHelper<T>::Read(srcValue, &dst->Value);
                 dst->IsSetFlag = true;
             } catch (NJson::TJsonException) {
-                ythrow TCatBoostException() << "Can't parse parameter \"" << key << "\" with value: " << srcValue;
+                ythrow TCatBoostException() << "Can't parse parameter \"" << key << "\" with value: " << srcValue
+                                            << " as " << TypeName<T>();
             }
             return true;
         } else {

--- a/catboost/private/libs/options/ut/json_helper_ut.cpp
+++ b/catboost/private/libs/options/ut/json_helper_ut.cpp
@@ -158,6 +158,27 @@ Y_UNIT_TEST_SUITE(TJsonHelperTest) {
         SaveFields(&tree2, option1, option2);
         UNIT_ASSERT_VALUES_EQUAL(ToString<NJson::TJsonValue>(tree2), "{\"option_1\":102}");
     }
+
+    Y_UNIT_TEST(TestWrongTypeErrorMessage) {
+        // https://github.com/catboost/catboost/issues/872
+        // Passing a floating point value for an integer parameter must produce an error message
+        // that mentions both the failing value and the expected type.
+        TStringBuf jsonStr = ""
+                             "{\n"
+                             "  \"leaf_estimation_iterations\": 86.85434834\n"
+                             "}"
+                             "";
+
+        NJson::TJsonValue tree;
+        NJson::ReadJsonTree(jsonStr, &tree);
+        TOption<int> option("leaf_estimation_iterations", 1);
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            TJsonFieldHelper<decltype(option)>::Read(tree, &option),
+            TCatBoostException,
+            "Can't parse parameter \"leaf_estimation_iterations\" with value: 86.85434834 as int");
+    }
+
         Y_UNIT_TEST(TestPlainAndReversePlainSerialization) {
             TString jsonPlain = ""
                 "{\n"

--- a/catboost/private/libs/options/ut/json_helper_ut.cpp
+++ b/catboost/private/libs/options/ut/json_helper_ut.cpp
@@ -78,6 +78,27 @@ Y_UNIT_TEST_SUITE(TJsonHelperTest) {
         UNIT_ASSERT_VALUES_EQUAL(serializedTree["option_val"], tree["option_val"]);
     }
 
+    Y_UNIT_TEST(TestTOptionParseErrorContainsExpectedType) {
+        TStringBuf json = ""
+            "{\n"
+            "    \"leaf_estimation_iterations\": 86.85434834\n"
+            "}";
+
+        NJson::TJsonValue tree;
+        NJson::ReadJsonTree(json, &tree);
+
+        TOption<int> parsedOption("leaf_estimation_iterations", 10);
+
+        try {
+            TJsonFieldHelper<decltype(parsedOption)>::Read(tree, &parsedOption);
+            UNIT_ASSERT_C(false, "Expected TCatBoostException");
+        } catch (const TCatBoostException& e) {
+            UNIT_ASSERT(e.AsStrBuf().Contains("Can't parse parameter \"leaf_estimation_iterations\""));
+            UNIT_ASSERT(e.AsStrBuf().Contains("with value"));
+            UNIT_ASSERT(e.AsStrBuf().Contains(" as int"));
+        }
+    }
+
     Y_UNIT_TEST(TestJsonSerializationWithFloatingPointValues) {
         TVector<double> values = {1.0f, 0.4f, 12.33f, 1.e-6f, 0.0f};
 


### PR DESCRIPTION
## Why

CatBoost issue #872 reports that when an integer option receives a floating point value, the parse error message does not clearly show the expected type. This makes configuration errors harder to debug because users can see the invalid value but not the type CatBoost expected.

Clear wrong-type error messages are useful for users debugging training parameter configuration issues.

## What changed

This PR improves coverage for wrong-type JSON parsing errors in `TOption<T>`.

It verifies that passing a floating point value for the integer option `leaf_estimation_iterations` produces an exception message containing:

- the failing parameter name
- the invalid value
- the expected type, such as `int`

Closes #872.

## Acceptance checklist

- [x] Added regression test for the changed behavior
- [x] Test follows existing patterns in `json_helper_ut.cpp`
- [x] Change is scoped to the issue
- [x] No unrelated formatting changes
- [x] No breaking changes intended
- [ ] Full local test suite passed — not completed locally because the targeted Ninja test target was not found in my local build environment

## Testing evidence

Added regression coverage in:

`catboost/private/libs/options/ut/json_helper_ut.cpp`

The new test checks that parsing:

```json
{
  "leaf_estimation_iterations": 86.85434834
}