### PR TITLE
Fix get_object_importance compatibility error for MultiClass models

### DIFF
--- a/catboost/libs/model/model.cpp
+++ b/catboost/libs/model/model.cpp
@@ -1376,7 +1376,12 @@ static TMaybe<NCatboostOptions::TLossDescription> GetLossDescription(const TFull
     TMaybe<NCatboostOptions::TLossDescription> lossDescription;
     if (model.ModelInfo.contains("loss_function")) {
         lossDescription.ConstructInPlace();
-        lossDescription->Load(ReadTJsonValue(model.ModelInfo.at("loss_function")));
+        auto lossJson = ReadTJsonValue(model.ModelInfo.at("loss_function"));
+        if (lossJson.GetType() != NJson::JSON_NULL && lossJson.GetType() != NJson::JSON_UNDEFINED) {
+            lossDescription->Load(lossJson);
+        } else {
+            *lossDescription = NCatboostOptions::ParseLossDescription(model.ModelInfo.at("loss_function"));
+        }
     }
     if (model.ModelInfo.contains("params")) {
         const auto& params = ReadTJsonValue(model.ModelInfo.at("params"));

--- a/catboost/private/libs/options/loss_description.cpp
+++ b/catboost/private/libs/options/loss_description.cpp
@@ -52,7 +52,11 @@ ELossFunction NCatboostOptions::TLossDescription::GetLossFunction() const {
 }
 
 void NCatboostOptions::TLossDescription::Load(const NJson::TJsonValue& options) {
-    CheckedLoad(options, &LossFunction, &LossParams);
+    if (options.IsString()) {
+        *this = ParseLossDescription(options.GetString());
+    } else {
+        CheckedLoad(options, &LossFunction, &LossParams);
+    }
 }
 
 void NCatboostOptions::TLossDescription::Save(NJson::TJsonValue* options) const {

--- a/catboost/private/libs/target/data_providers.cpp
+++ b/catboost/private/libs/target/data_providers.cpp
@@ -968,7 +968,12 @@ namespace NCB {
         TMaybe<NCatboostOptions::TLossDescription> modelLossDescription;
         if (const auto* modelInfoLoss = MapFindPtr(model.ModelInfo, "loss_function")) {
             modelLossDescription.ConstructInPlace();
-            modelLossDescription->Load(ReadTJsonValue(*modelInfoLoss));
+            auto lossJson = ReadTJsonValue(*modelInfoLoss);
+            if (lossJson.GetType() != NJson::JSON_NULL && lossJson.GetType() != NJson::JSON_UNDEFINED) {
+                modelLossDescription->Load(lossJson);
+            } else {
+                *modelLossDescription = NCatboostOptions::ParseLossDescription(*modelInfoLoss);
+            }
         } else if (const auto* modelInfoParams = MapFindPtr(model.ModelInfo, "params")) {
             NJson::TJsonValue paramsJson = ReadTJsonValue(*modelInfoParams);
 

--- a/test_catboost.py
+++ b/test_catboost.py
@@ -1,0 +1,16 @@
+from catboost import CatBoostClassifier, Pool
+import numpy as np
+
+X = np.random.rand(100, 10)
+y = np.random.randint(0, 3, 100)
+
+model = CatBoostClassifier(iterations=10, loss_function='MultiClass', allow_writing_files=False)
+model.fit(X, y, verbose=False)
+
+try:
+    print("Trying get_object_importance...")
+    model.get_object_importance(Pool(X, y), Pool(X, y), type='Average', update_method='SinglePoint')
+    print("Success")
+except Exception as e:
+    print("Failed!")
+    print(e)


### PR DESCRIPTION
Fixes a bug where `get_object_importance` fails on multidimensional models (like `MultiClass`) with an `RMSE` incompatibility error. 

The error occurred because `loss_function` strings (e.g. `loss_function="MultiClass"`) were silently failing to parse in `ReadTJsonValue`, causing the metric to mistakenly default to `RMSE`. 

Added a fallback in `data_providers.cpp`, `model.cpp`, and `loss_description.cpp` to correctly parse raw string loss functions via `ParseLossDescription`. Included `test_catboost.py` to verify the fix.
