### PR TITLE
Fix #2387: list only used features in per-tree PMML MiningSchema

### DIFF
--- a/catboost/libs/model/model_export/pmml_helpers.cpp
+++ b/catboost/libs/model/model_export/pmml_helpers.cpp
@@ -12,6 +12,7 @@
 #include <util/datetime/base.h>
 #include <util/generic/algorithm.h>
 #include <util/generic/cast.h>
+#include <util/generic/hash_set.h>
 #include <util/generic/vector.h>
 #include <util/generic/xrange.h>
 #include <util/stream/file.h>
@@ -129,27 +130,40 @@ static void OutputMiningSchemaWithModelFeatures(
     const TFullModel& model,
     bool mappedCategoricalFeatures,
     TMaybe<TStringBuf> targetName, // if nothing - don't output it
-    TXmlOutputContext* xmlOut) {
+    TXmlOutputContext* xmlOut,
+    const THashSet<int>* usedFloatFeatures = nullptr,
+    const THashSet<int>* usedCatFeatures = nullptr) {
 
     TXmlElementOutputContext miningSchema(xmlOut, "MiningSchema");
 
-    for (const auto& floatFeature : model.ModelTrees->GetFloatFeatures()) {
+    const auto& floatFeatures = model.ModelTrees->GetFloatFeatures();
+    for (auto floatFeatureIdx : xrange(floatFeatures.size())) {
+        if (usedFloatFeatures && !usedFloatFeatures->contains(SafeIntegerCast<int>(floatFeatureIdx))) {
+            continue;
+        }
         TXmlElementOutputContext miningField(xmlOut, "MiningField");
-        xmlOut->AddAttr("name", CreateFeatureName(floatFeature)).AddAttr("usageType", "active");
+        xmlOut->AddAttr("name", CreateFeatureName(floatFeatures[floatFeatureIdx])).AddAttr("usageType", "active");
     }
 
     const auto& modelTrees = model.ModelTrees;
 
     if (mappedCategoricalFeatures) {
         for (const auto& oneHotFeature : modelTrees->GetOneHotFeatures()) {
+            if (usedCatFeatures && !usedCatFeatures->contains(oneHotFeature.CatFeatureIndex)) {
+                continue;
+            }
             TXmlElementOutputContext miningField(xmlOut, "MiningField");
             xmlOut->AddAttr("name", CreateFeatureName(modelTrees->GetCatFeatures()[oneHotFeature.CatFeatureIndex]) + "_mapped")
                 .AddAttr("usageType", "active");
         }
     } else {
-        for (const auto& catFeature : modelTrees->GetCatFeatures()) {
+        const auto& catFeatures = modelTrees->GetCatFeatures();
+        for (auto catFeatureIdx : xrange(catFeatures.size())) {
+            if (usedCatFeatures && !usedCatFeatures->contains(SafeIntegerCast<int>(catFeatureIdx))) {
+                continue;
+            }
             TXmlElementOutputContext miningField(xmlOut, "MiningField");
-            xmlOut->AddAttr("name", CreateFeatureName(catFeature))
+            xmlOut->AddAttr("name", CreateFeatureName(catFeatures[catFeatureIdx]))
                 .AddAttr("usageType", "active");
         }
     }
@@ -157,6 +171,33 @@ static void OutputMiningSchemaWithModelFeatures(
     if (targetName) {
         TXmlElementOutputContext miningField(xmlOut, "MiningField");
         xmlOut->AddAttr("name", *targetName).AddAttr("usageType", "target");
+    }
+}
+
+static void CollectUsedFeatures(
+    const TModelTrees& modelTrees,
+    size_t treeIdx,
+    THashSet<int>* usedFloatFeatures,
+    THashSet<int>* usedCatFeatures) {
+
+    const auto& treeData = *modelTrees.GetModelTreeData();
+    const auto treeStartOffset = treeData.GetTreeStartOffsets()[treeIdx];
+    const auto treeSize = treeData.GetTreeSizes()[treeIdx];
+
+    for (auto nodeIdx : xrange(treeStartOffset, treeStartOffset + treeSize)) {
+        if (!modelTrees.IsOblivious()) {
+            const auto& stepNode = treeData.GetNonSymmetricStepNodes()[nodeIdx];
+            if ((stepNode.LeftSubtreeDiff == 0) && (stepNode.RightSubtreeDiff == 0)) {
+                continue;
+            }
+        }
+        const auto& binFeature = modelTrees.GetBinFeatures()[treeData.GetTreeSplits()[nodeIdx]];
+        if (binFeature.Type == ESplitType::FloatFeature) {
+            usedFloatFeatures->insert(binFeature.FloatFeature.FloatFeature);
+        } else {
+            Y_ASSERT(binFeature.Type == ESplitType::OneHotFeature);
+            usedCatFeatures->insert(binFeature.OneHotFeature.CatFeatureIdx);
+        }
     }
 }
 
@@ -494,7 +535,17 @@ static void OutputTree(
         .AddAttr("missingValueStrategy", "defaultChild")
         .AddAttr("splitCharacteristic", "binarySplit");
 
-    OutputMiningSchemaWithModelFeatures(model, /*mappedCategoricalFeatures*/ true, targetName, xmlOut);
+    THashSet<int> usedFloatFeatures;
+    THashSet<int> usedCatFeatures;
+    CollectUsedFeatures(*model.ModelTrees, treeIdx, &usedFloatFeatures, &usedCatFeatures);
+
+    OutputMiningSchemaWithModelFeatures(
+        model,
+        /*mappedCategoricalFeatures*/ true,
+        targetName,
+        xmlOut,
+        &usedFloatFeatures,
+        &usedCatFeatures);
 
     {
         TXmlElementOutputContext output(xmlOut, "Output");

--- a/catboost/private/libs/algo/full_model_saver.cpp
+++ b/catboost/private/libs/algo/full_model_saver.cpp
@@ -766,7 +766,8 @@ namespace NCB {
                 [] (EModelType format) {
                     return format == EModelType::Python ||
                         format == EModelType::Cpp ||
-                        format == EModelType::Json;
+                        format == EModelType::Json ||
+                        format == EModelType::Pmml;
                 }
             );
             if (anyExportFormatRequiresCatFeaturesHashToString) {


### PR DESCRIPTION
Fixes #2387

The PMML exporter was writing every model feature into the `MiningSchema` of every tree `<Segment>`, even though a single tree usually splits on just a few of them. So file size scaled with trees × features, which gets bad quickly for wide models.

This PR adds a small `CollectUsedFeatures` helper in `pmml_helpers.cpp` that walks a tree's split conditions and collects the float/one-hot features it actually uses, and each `TreeModel`'s `MiningSchema` is now built from that set only. For non-symmetric trees, leaf nodes are skipped since their split slots are unused. The top-level `MiningModel` schema is left as is - it still declares all model features, matching the `DataDictionary`.

While testing I hit a separate pre-existing bug: `catboost fit --model-format PMML` crashed with `Key not found in hashtable` for any model with one-hot features, because `ExportFullModel` in `full_model_saver.cpp` only built `catFeaturesHashToString` for the Python/Cpp/Json formats. I added `Pmml` to that list. `AppleCoreML` looks like it has the same problem, but I left it alone to keep this PR focused.

To test it, I built the CLI locally (`build_native.py`, macOS arm64) and trained with a fixed seed and a single thread, so the pre/post-fix models are identical (same predictions, same predicate sequences in the PMML). Checked oblivious and Lossguide regression models with float + one-hot categorical features, plus a Logloss model on the `adult` test dataset - in all cases every tree segment's `MiningSchema` now matches exactly the fields referenced by its `SimplePredicate`s. On a 100-feature, 100-tree, depth-6 model the export went from 1,741,026 to 1,268,373 bytes (−27%), and the savings grow with feature count.

One thing: the canonical data of `test_pmml_export` (`catboost/python-package/ut/medium/test.py`) will need re-canonization since the exported PMML legitimately shrinks.