### PR TITLE
Added the build flags for asan, ubsan, tsan in build_native.py

### DIFF
--- a/build/build_native.py
+++ b/build/build_native.py
@@ -103,6 +103,9 @@ class Opts(object):
         ),
         'macosx_version_min': Option('Minimal macOS version to target', default='11.0'),
         'have_cuda': Option('Enable CUDA support', default=False, opt_type=bool),
+        'with_asan': Option('Enable AddressSanitizer (incompatible with --with-tsan)', default=False, opt_type=bool),
+        'with_ubsan': Option('Enable UndefinedBehaviorSanitizer (incompatible with --with-tsan)', default=False, opt_type=bool),
+        'with_tsan': Option('Enable ThreadSanitizer (incompatible with --with-asan and --with-ubsan)', default=False, opt_type=bool),
         'cuda_root_dir': Option('CUDA root dir (taken from CUDA_PATH or CUDA_ROOT by default)'),
         'cuda_runtime_library': Option('CMAKE_CUDA_RUNTIME_LIBRARY for CMake', default='Static'),
         'android_ndk_root_dir': Option('Path to Android NDK root'),
@@ -457,6 +460,33 @@ def get_catboost_components(targets : Iterable[str]) -> Set[str]:
 
     return catboost_components
 
+def get_sanitizer_cmake_args(opts: Opts) -> List[str]:
+    sanitizers = []
+    if opts.with_asan:
+        sanitizers.append('address')
+    if opts.with_ubsan:
+        sanitizers.append('undefined')
+    if opts.with_tsan:
+        sanitizers.append('thread')
+
+    if not sanitizers:
+        return []
+    if opts.have_cuda:
+        raise RuntimeError('Sanitizers are not supported together with CUDA builds')
+    if opts.with_tsan and len(sanitizers) > 1:
+        raise RuntimeError('ThreadSanitizer cannot be combined with AddressSanitizer or UndefinedBehaviorSanitizer')
+    if opts.with_tsan and platform.system().lower() == 'windows':
+        raise RuntimeError('ThreadSanitizer is not supported on Windows')
+
+    sanitizer_flags = f'-fsanitize={",".join(sanitizers)}'
+    if platform.system().lower() != 'windows':
+        sanitizer_flags += ' -fno-omit-frame-pointer'
+    return [
+        '-DCUSTOM_ALLOCATORS=Off',
+        f'-DCMAKE_C_FLAGS_INIT={sanitizer_flags}',
+        f'-DCMAKE_CXX_FLAGS_INIT={sanitizer_flags}'
+    ]
+
 def get_default_build_platform_toolchain(source_root_dir: str) -> str:
     if platform.system().lower() == 'windows':
         return os.path.abspath(os.path.join(source_root_dir, 'build', 'toolchains', 'default.toolchain'))
@@ -625,6 +655,8 @@ def build(
             f'-DCUDAToolkit_ROOT={os.path.splitdrive(cuda_root_dir)[1] if cmake_platform_to_root_path is not None else cuda_root_dir}',
             f'-DCMAKE_CUDA_RUNTIME_LIBRARY={opts.cuda_runtime_library}'
         ]
+
+    cmake_cmd += get_sanitizer_cmake_args(opts)
 
     if opts.native_built_tools_root_dir:
         cmake_cmd += [f'-DTOOLS_ROOT={opts.native_built_tools_root_dir}']

--- a/build/test_build_native.py
+++ b/build/test_build_native.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest import mock
+
+from build import build_native
+
+
+class TestSanitizerCmakeArgs(unittest.TestCase):
+    def make_opts(self, **kwargs):
+        return build_native.Opts(build_root_dir='build', targets=['catboost'], **kwargs)
+
+    def test_asan_and_ubsan_flags(self):
+        cmake_args = build_native.get_sanitizer_cmake_args(
+            self.make_opts(with_asan=True, with_ubsan=True)
+        )
+
+        self.assertEqual(
+            cmake_args,
+            [
+                '-DCUSTOM_ALLOCATORS=Off',
+                '-DCMAKE_C_FLAGS_INIT=-fsanitize=address,undefined -fno-omit-frame-pointer',
+                '-DCMAKE_CXX_FLAGS_INIT=-fsanitize=address,undefined -fno-omit-frame-pointer'
+            ]
+        )
+
+    def test_tsan_cannot_be_combined_with_asan(self):
+        with self.assertRaisesRegex(RuntimeError, 'ThreadSanitizer cannot be combined'):
+            build_native.get_sanitizer_cmake_args(self.make_opts(with_asan=True, with_tsan=True))
+
+    def test_sanitizers_cannot_be_combined_with_cuda(self):
+        with self.assertRaisesRegex(RuntimeError, 'Sanitizers are not supported together with CUDA builds'):
+            build_native.get_sanitizer_cmake_args(self.make_opts(with_asan=True, have_cuda=True))
+
+    @mock.patch.object(build_native.platform, 'system', return_value='Windows')
+    def test_windows_asan_does_not_use_unix_frame_pointer_flag(self, _platform_system):
+        cmake_args = build_native.get_sanitizer_cmake_args(self.make_opts(with_asan=True))
+
+        self.assertEqual(
+            cmake_args,
+            [
+                '-DCUSTOM_ALLOCATORS=Off',
+                '-DCMAKE_C_FLAGS_INIT=-fsanitize=address',
+                '-DCMAKE_CXX_FLAGS_INIT=-fsanitize=address'
+            ]
+        )
+
+    @mock.patch.object(build_native.platform, 'system', return_value='Windows')
+    def test_windows_tsan_is_not_supported(self, _platform_system):
+        with self.assertRaisesRegex(RuntimeError, 'ThreadSanitizer is not supported on Windows'):
+            build_native.get_sanitizer_cmake_args(self.make_opts(with_tsan=True))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/catboost/docs/en/installation/build-native-artifacts.md
+++ b/catboost/docs/en/installation/build-native-artifacts.md
@@ -77,6 +77,16 @@ The required options are:
 
 Importantly, `build_native.py` has `--dry-run` and `--verbose` options so you can examine the commands it is going to run without actually running them.
 
+### Sanitizers
+
+For CPU builds, `build_native.py` provides flags for the most common Clang sanitizers:
+
+- `--with-asan` enables AddressSanitizer, which detects memory-safety errors such as out-of-bounds accesses and use-after-free.
+- `--with-ubsan` enables UndefinedBehaviorSanitizer, which detects many forms of undefined behavior.
+- `--with-tsan` enables ThreadSanitizer, which detects data races.
+
+`--with-asan` and `--with-ubsan` can be used together. ThreadSanitizer cannot be combined with either of them and is not supported on Windows. Sanitizer builds disable CatBoost's custom allocators so that the sanitizer can instrument allocations. They are not supported together with `--have-cuda`; use a separate build directory for each sanitizer configuration.
+
 ### Examples
 
 - Build `catboost` CLI app for the current platform without CUDA:
@@ -95,6 +105,18 @@ Importantly, `build_native.py` has `--dry-run` and `--verbose` options so you ca
 
   ```
   python $CATBOOST_SRC_ROOT/build/build_native.py --targets catboost --build-root-dir=./build_with_cuda_11 --have-cuda --cuda-root-dir=/usr/local/cuda-11/
+  ```
+
+- Build `catboost` CLI app with AddressSanitizer and UndefinedBehaviorSanitizer. `RelWithDebInfo` retains useful stack traces while still optimizing the binary:
+
+  ```
+  python $CATBOOST_SRC_ROOT/build/build_native.py --build-root-dir=./build_asan_ubsan --build-type=RelWithDebInfo --targets catboost --with-asan --with-ubsan
+  ```
+
+- Build `catboost` CLI app with ThreadSanitizer:
+
+  ```
+  python $CATBOOST_SRC_ROOT/build/build_native.py --build-root-dir=./build_tsan --build-type=RelWithDebInfo --targets catboost --with-tsan
   ```
 
 - Build C/C++ applier shared library as a macOS universal binary with macOS minimal version set to 11.0:


### PR DESCRIPTION
# Summary

This PR adds sanitizer-friendly build flags to `build/build_native.py` and documents how to use them when building native CatBoost artifacts.

Fixes #3029 

# Changes

- Added sanitizer build flags to `build/build_native.py`
- Added documentation for sanitizer builds in `catboost/docs/en/installation/build-native-artifacts.md`
- Added validation for unsupported combinations:
  - sanitizers with CUDA
  - ThreadSanitizer with AddressSanitizer/UndefinedBehaviorSanitizer
  - ThreadSanitizer on Windows
- Disabled custom allocators automatically for sanitizer builds
- Wired sanitizer flags through CMake init flags so they are preserved by the CatBoost CMake flow

# Supported flags

- `--with-asan`
- `--with-ubsan`
- `--with-tsan`

Supported combinations:
- `--with-asan`
- `--with-ubsan`
- `--with-asan --with-ubsan`
- `--with-tsan`

Unsupported combinations:
- any sanitizer with CUDA
- `--with-tsan` together with `--with-asan` or `--with-ubsan`

# Documentation

Updated:
- `catboost/docs/en/installation/build-native-artifacts.md`

Added:
- sanitizer flag descriptions
- usage examples
- compatibility notes and limitations

# Testing

- `python3 -m unittest build.test_build_native`
- Built CatBoost with `--with-asan --with-ubsan`
- Verified generated compile commands include:

  `-fsanitize=address,undefined -fno-omit-frame-pointer`

- Ran CatBoost CLI under sanitizer build on a tiny training sample:

  `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 ./build_asan_ubsan_fixed/catboost/app/catboost fit --task-type CPU --loss-function Logloss --learn-set /tmp/train.tsv --column-description /tmp/cd.txt --iterations 5 --model-file /tmp/model.bin`

- Training completed successfully with no ASan/UBSan report

# Notes

- The generated compile flags plus successful execution of a sanitizer-built binary.
- Windows support for these sanitizer flag changes is still under testing.