### PR TITLE
Validate leaf_values count when loading oblivious trees from JSON

### DIFF
--- a/catboost/libs/model/model_export/json_model_helpers.cpp
+++ b/catboost/libs/model/model_export/json_model_helpers.cpp
@@ -378,7 +378,14 @@ static void GetObliviousModelTrees(const TJsonValue& jsonValue, TModelTrees* mod
         }
         int treeSize = value["splits"].GetArray().ysize();
         modelTrees->AddTreeSize(treeSize);
-        modelTrees->SetApproxDimension(value["leaf_values"].GetArray().ysize() / (1uLL << treeSize));
+        const ui64 leafValuesCount = value["leaf_values"].GetArray().ysize();
+        const ui64 leavesPerDimension = 1uLL << treeSize;
+        CB_ENSURE(
+            leafValuesCount > 0 && leafValuesCount % leavesPerDimension == 0,
+            "Invalid oblivious tree in JSON model: leaf_values count (" << leafValuesCount
+                << ") must be a positive multiple of 2^depth (" << leavesPerDimension
+                << ") for tree of depth " << treeSize);
+        modelTrees->SetApproxDimension(leafValuesCount / leavesPerDimension);
         for (const auto& split: value["splits"].GetArray()) {
             modelTrees->AddTreeSplit(split["split_index"].GetInteger());
         }

--- a/catboost/libs/model/ut/json_model_export_ut.cpp
+++ b/catboost/libs/model/ut/json_model_export_ut.cpp
@@ -2,7 +2,11 @@
 
 #include <catboost/libs/model/model_export/model_exporter.h>
 
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/json_writer.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <util/stream/file.h>
 
 using namespace std;
 using namespace NCB;
@@ -31,5 +35,40 @@ Y_UNIT_TEST_SUITE(TJsonModelExport) {
         ExportModel(model, "model.json", EModelType::Json);
         model = ReadModel("model.json", EModelType::Json);
         UNIT_ASSERT(model.ModelTrees->GetModelTreeData()->GetLeafWeights().empty());
+    }
+    Y_UNIT_TEST(TestMalformedLeafValuesCountRejected) {
+        // A JSON model whose oblivious tree has a leaf_values count that is not a
+        // multiple of 2^depth must be rejected instead of silently truncating the
+        // approx dimension (which later causes out-of-bounds leaf reads at apply time).
+        TFullModel model = TrainFloatCatboostModel();
+        ExportModel(model, "model.json", EModelType::Json);
+
+        NJson::TJsonValue jsonModel;
+        {
+            TIFStream in("model.json");
+            NJson::ReadJsonTree(&in, &jsonModel, /*throwOnError*/ true);
+        }
+        NJson::TJsonValue& trees = jsonModel["oblivious_trees"];
+        UNIT_ASSERT(trees.GetArray().size() > 0);
+
+        // Drop one leaf value from the first tree so the count is no longer a
+        // multiple of 2^depth.
+        NJson::TJsonValue& leafValues = trees[0]["leaf_values"];
+        UNIT_ASSERT(leafValues.GetArray().size() > 1);
+        NJson::TJsonValue truncated(NJson::JSON_ARRAY);
+        const auto& src = leafValues.GetArray();
+        for (size_t i = 0; i + 1 < src.size(); ++i) {
+            truncated.AppendValue(src[i]);
+        }
+        leafValues = truncated;
+
+        {
+            TOFStream out("model_malformed.json");
+            NJson::WriteJson(&out, &jsonModel);
+        }
+
+        UNIT_ASSERT_EXCEPTION(
+            ReadModel("model_malformed.json", EModelType::Json),
+            TCatBoostException);
     }
 }


### PR DESCRIPTION
### What

Fixes #3137.

`GetObliviousModelTrees()` in `catboost/libs/model/model_export/json_model_helpers.cpp` computed the approx dimension via an unchecked integer division:

```cpp
modelTrees->SetApproxDimension(value["leaf_values"].GetArray().ysize() / (1uLL << treeSize));
```

When a JSON model's `leaf_values` count is not a positive multiple of `2^depth`, the division silently truncates and produces a wrong `ApproxDimension`. The malformed model then loads without any error and can lead to out-of-bounds leaf reads at apply time, instead of failing fast at load time.

### Change

- Add a `CB_ENSURE` guard in `GetObliviousModelTrees()` so a `leaf_values` count that is not a positive multiple of `2^depth` is rejected at load with a clear message.
- Add a unit test `TestMalformedLeafValuesCountRejected` in `catboost/libs/model/ut/json_model_export_ut.cpp` that exports a valid model, drops one leaf value so the count is no longer a multiple of `2^depth`, and asserts the loader raises `TCatBoostException`.

### Scope

This is a data-integrity / robustness fix for local JSON model loading — it makes a malformed model fail fast with a clear error rather than loading silently. It is **not** a remotely exploitable memory-safety issue.

### Verification

- Full `model_ut` suite passes locally (36/36).
- The new test fails on the unpatched loader (silent acceptance) and passes with the guard in place (red → green).
