### PR TITLE
Fix parts of the documentation that used template variables from presets.yaml and were lost during documention platform migration.

### DIFF
--- a/catboost/docs/en/_includes/work_src/reusage-python/how-to-train-on-gpu.md
+++ b/catboost/docs/en/_includes/work_src/reusage-python/how-to-train-on-gpu.md
@@ -1,7 +1,7 @@
 
 {% note info %}
 
-Set the `task_type` parameter in the class constructor to  to train the model on GPU. Training on GPU requires NVIDIA Driver of version 450.xx or higher.
+Set the `task_type` parameter in the class constructor to {{ calcer_type__gpu }} to train the model on GPU. Training on GPU requires NVIDIA Driver of version 450.xx or higher.
 
 {% endnote %}
 

--- a/catboost/docs/en/concepts/input-data_values-file.md
+++ b/catboost/docs/en/concepts/input-data_values-file.md
@@ -37,7 +37,7 @@ The column indexed 4 contains arbitrary data.
 
 {% include [reusage-file-with-column-descs](../_includes/work_src/reusage/file-with-column-descs.md) %}
 
-The feature indexed 3 is categorical, so the value in the second column of the description file is set to . The name of this feature is set to <q>wind direction</q> in the third column of the description file.
+The feature indexed 3 is categorical, so the value in the second column of the description file is set to {{ cd-file__col-type__Categ }}. The name of this feature is set to <q>wind direction</q> in the third column of the description file.
 
 Other features are numerical and are omitted from the columns description file.
 

--- a/catboost/docs/en/concepts/output-data_training-log.md
+++ b/catboost/docs/en/concepts/output-data_training-log.md
@@ -63,7 +63,7 @@ Contains basic information about the training.
 Property | Type | Description
 ----- | ----- | -----
 `launch_mode` | {{ json__string }} | The specified launch mode.<br/><br/>Possible values:<br/>- Train — Training launch mode.<br/>- CV — Cross-validation launch mode (for the Python [cv](python-reference_cv.md) method only).<br/><br/>The command-line implementation of the [Cross-validation](cli-reference_cross-validation.md) feature returns the Train value in this parameter.<br/><br/>{% endnote %}
-`name` | {{ json__string }} | The experiment name.<br/><br/>The value can be set in the `--name` (`--name`) training parameter. The default name is .
+`name` | {{ json__string }} | The experiment name.<br/><br/>The value can be set in the `--name` (`--name`) training parameter. The default name is {{ fit--name }}.
 `iteration_count` | {{ json__int }} | The maximum number of trees that can be built when solving machine learning problems.<br>The final number of iterations may be less than the output in this property.
 `learn_metrics` | {{ json__array }} | A list of metrics calculated for the learning dataset and information regarding the optimization method.
 `test_sets` | {{ json__array }} | The names of the arrays within the [iterations](#iterations__array) array that contain the calculated values of metrics for the validation datasets.

--- a/catboost/docs/en/concepts/speed-up-training.md
+++ b/catboost/docs/en/concepts/speed-up-training.md
@@ -35,7 +35,7 @@ Command-line version parameters|     Python parameters                          
 
 ## Boosting type {#boosting-type}
 
-By default, the boosting type is set to  for small datasets. This prevents overfitting but it is expensive in terms of computation. Try to set the value of this parameter to  to speed up the training.
+By default, the boosting type is set to {{ fit__boosting-type__ordered }} for small datasets. This prevents overfitting but it is expensive in terms of computation. Try to set the value of this parameter to {{ fit__boosting-type__plain }} to speed up the training.
 
 {% cut "{{ dl--parameters }}" %}
 
@@ -48,7 +48,7 @@ Command-line version parameters|Python parameters|R parameters|
 
 ## Bootstrap type {#bootstrap-type}
 
-By default, the method for sampling the weights of objects is set to . The training is performed faster if the  method is set and the value for the sample rate for bagging is smaller than 1.
+By default, the method for sampling the weights of objects is set to {{ fit__bootstrap-type__Bayesian }}. The training is performed faster if the {{ fit__bootstrap-type__Bernoulli }} method is set and the value for the sample rate for bagging is smaller than 1.
 
 {% cut "{{ dl--parameters }}" %}
 


### PR DESCRIPTION
Closes #3135 