### PR TITLE
Support pandas nullable dtypes and pandas.NA/NaT as missing values in Python package

### DIFF
--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -51,6 +51,18 @@ except ImportError:
 
 _polars_is_series_of_list_to_numpy_correct = _polars_version >= (1, 9)
 
+# pandas.NA singleton is available only since pandas 1.0.0
+_pandas_NA = getattr(pd, 'NA', None)
+_pandas_NaT = getattr(pd, 'NaT', None)
+
+# names of pandas nullable extension dtypes for numeric and boolean data
+_pandas_nullable_numeric_dtype_names = frozenset([
+    'Int8', 'Int16', 'Int32', 'Int64',
+    'UInt8', 'UInt16', 'UInt32', 'UInt64',
+    'Float32', 'Float64',
+    'boolean'
+])
+
 np.import_array()
 
 cimport cython
@@ -1284,6 +1296,8 @@ cdef inline float _FloatOrNan(object obj) except *:
     cdef type obj_type = type(obj)
     if obj is None:
         return _FLOAT_NAN
+    elif obj is _pandas_NA or obj is _pandas_NaT:
+        return _FLOAT_NAN
     elif obj_type is float:
         return <float>obj
     elif obj_type is str or obj_type is unicode or obj_type is bytes or obj_type is _npbytes_ or obj_type is _npunicode_ or isinstance(obj, string_types + (_npbytes_, _npunicode_)):
@@ -2184,6 +2198,8 @@ cdef inline get_id_object_bytes_string_representation(
             # for some reason Cython does not allow assignment to dereferenced pointer, so use this trick instead
             bytes_string_buf_representation[0] = to_arcadia_string(id_object)
         else:
+            if id_object is _pandas_NA or id_object is _pandas_NaT:
+                raise CatBoostError("bad object for id: {}".format(id_object))
             if isnan(id_object) or int(id_object) != id_object:
                 raise CatBoostError("bad object for id: {}".format(id_object))
             bytes_string_buf_representation[0] = ToString[i64](int(id_object))
@@ -3186,6 +3202,10 @@ cdef object _set_features_order_data_pd_data_frame(
                     new_data_holders
                 )
             else:
+                if column_data.dtype.name in _pandas_nullable_numeric_dtype_names:
+                    # pandas nullable numeric/boolean extension dtypes:
+                    # missing values (pandas.NA) are converted to NaN in a vectorized way
+                    column_values = column_data.to_numpy(dtype=np.float32, na_value=np.nan)
                 new_data_holders += create_num_factor_data(
                     flat_feature_idx,
                     column_values,

--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -51,6 +51,17 @@ except ImportError:
 
 _polars_is_series_of_list_to_numpy_correct = _polars_version >= (1, 9)
 
+# pandas.NA singleton is available only since pandas 1.0.0
+_pandas_NA = getattr(pd, 'NA', None)
+
+# names of pandas nullable extension dtypes for numeric and boolean data
+_pandas_nullable_numeric_dtype_names = frozenset([
+    'Int8', 'Int16', 'Int32', 'Int64',
+    'UInt8', 'UInt16', 'UInt32', 'UInt64',
+    'Float32', 'Float64',
+    'boolean'
+])
+
 np.import_array()
 
 cimport cython
@@ -1283,6 +1294,8 @@ cdef inline float _FloatOrNan(object obj) except *:
     # here lies fastpath
     cdef type obj_type = type(obj)
     if obj is None:
+        return _FLOAT_NAN
+    elif obj is _pandas_NA:
         return _FLOAT_NAN
     elif obj_type is float:
         return <float>obj
@@ -3165,20 +3178,22 @@ cdef object _set_features_order_data_pd_data_frame(
                 py_builder_visitor
             )
         else:
-            column_values = column_data.to_numpy()
             if is_cat_feature_mask[flat_feature_idx]:
+                column_values = column_data.to_numpy()
                 _set_features_order_data_frame_generic_categorical_column(
                     flat_feature_idx,
                     column_values,
                     builder_visitor
                 )
             elif is_text_feature_mask[flat_feature_idx]:
+                column_values = column_data.to_numpy()
                 _set_features_order_data_frame_generic_text_column(
                     flat_feature_idx,
                     column_values,
                     builder_visitor
                 )
             elif is_embedding_feature_mask[flat_feature_idx]:
+                column_values = column_data.to_numpy()
                 create_embedding_factor_data(
                     flat_feature_idx,
                     column_values,
@@ -3186,6 +3201,12 @@ cdef object _set_features_order_data_pd_data_frame(
                     new_data_holders
                 )
             else:
+                if column_data.dtype.name in _pandas_nullable_numeric_dtype_names:
+                    # pandas nullable numeric/boolean extension dtypes:
+                    # missing values (pandas.NA) are converted to NaN in a vectorized way
+                    column_values = column_data.to_numpy(dtype=np.float32, na_value=np.nan)
+                else:
+                    column_values = column_data.to_numpy()
                 new_data_holders += create_num_factor_data(
                     flat_feature_idx,
                     column_values,

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -103,6 +103,14 @@ FLOAT_TYPES = (float, np.floating)
 STRING_TYPES = (string_types,)
 ARRAY_TYPES = (list, np.ndarray, pd.DataFrame, pd.Series, pl.DataFrame, pl.Series)
 
+# names of pandas nullable extension dtypes for numeric and boolean data
+_PANDAS_NULLABLE_NUMERIC_DTYPE_NAMES = frozenset([
+    'Int8', 'Int16', 'Int32', 'Int64',
+    'UInt8', 'UInt16', 'UInt32', 'UInt64',
+    'Float32', 'Float64',
+    'boolean'
+])
+
 if sys.version_info >= (3, 6):
     PATH_TYPES = STRING_TYPES + (os.PathLike,)
 elif sys.version_info >= (3, 4):
@@ -1328,7 +1336,12 @@ class Pool(_PoolBase):
 
     def _label_if_pandas_to_numpy(self, label):
         if isinstance(label, pd.Series):
-            label = label.values
+            if label.dtype.name in _PANDAS_NULLABLE_NUMERIC_DTYPE_NAMES:
+                # pandas nullable numeric/boolean extension dtypes:
+                # convert to float64 with missing values (pandas.NA) represented as NaN
+                label = label.to_numpy(dtype=np.float64, na_value=np.nan)
+            else:
+                label = label.values
         if isinstance(label, pd.DataFrame):
             label = label.values
         return label

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -103,6 +103,14 @@ FLOAT_TYPES = (float, np.floating)
 STRING_TYPES = (string_types,)
 ARRAY_TYPES = (list, np.ndarray, pd.DataFrame, pd.Series, pl.DataFrame, pl.Series)
 
+# names of pandas nullable extension dtypes for numeric and boolean data
+_PANDAS_NULLABLE_NUMERIC_DTYPE_NAMES = frozenset([
+    'Int8', 'Int16', 'Int32', 'Int64',
+    'UInt8', 'UInt16', 'UInt32', 'UInt64',
+    'Float32', 'Float64',
+    'boolean'
+])
+
 if sys.version_info >= (3, 6):
     PATH_TYPES = STRING_TYPES + (os.PathLike,)
 elif sys.version_info >= (3, 4):
@@ -1349,7 +1357,12 @@ class Pool(_PoolBase):
 
     def _label_if_pandas_to_numpy(self, label):
         if isinstance(label, pd.Series):
-            label = label.values
+            if label.dtype.name in _PANDAS_NULLABLE_NUMERIC_DTYPE_NAMES:
+                # pandas nullable numeric/boolean extension dtypes:
+                # convert to float64 with missing values (pandas.NA) represented as NaN
+                label = label.to_numpy(dtype=np.float64, na_value=np.nan)
+            else:
+                label = label.values
         if isinstance(label, pd.DataFrame):
             label = label.values
         return label

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -11120,6 +11120,179 @@ def test_pandas_integer_array():
     cb.fit(X, y)
 
 
+_PANDAS_VERSION = tuple(map(int, re.findall(r'\d+', pd.__version__)[:2]))
+
+_PANDAS_NULLABLE_INT_DTYPES = ['Int8', 'Int16', 'Int32', 'Int64', 'UInt8', 'UInt16', 'UInt32', 'UInt64']
+# nullable floating point extension dtypes are available only since pandas 1.2.0
+_PANDAS_NULLABLE_FLOAT_DTYPES = ['Float32', 'Float64'] if _PANDAS_VERSION >= (1, 2) else []
+_PANDAS_NULLABLE_NUMERIC_DTYPES = _PANDAS_NULLABLE_INT_DTYPES + _PANDAS_NULLABLE_FLOAT_DTYPES + ['boolean']
+
+requires_pandas_nullable_types = pytest.mark.skipif(
+    _PANDAS_VERSION < (1, 0),
+    reason='pandas nullable types and pandas.NA are available only since pandas 1.0.0'
+)
+
+
+def _nullable_numeric_series_values(dtype):
+    if dtype == 'boolean':
+        return [True, False, pd.NA, True, False, True, False, pd.NA]
+    return [1, 2, pd.NA, 4, 5, 6, 7, pd.NA]
+
+
+def _expected_numeric_feature_values(dtype):
+    if dtype == 'boolean':
+        return [1.0, 0.0, np.nan, 1.0, 0.0, 1.0, 0.0, np.nan]
+    return [1.0, 2.0, np.nan, 4.0, 5.0, 6.0, 7.0, np.nan]
+
+
+def _check_single_feature_values(features, expected):
+    assert features.shape == (len(expected), 1)
+    for got, want in zip(features[:, 0], expected):
+        if np.isnan(want):
+            assert np.isnan(got)
+        else:
+            assert got == want
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', _PANDAS_NULLABLE_NUMERIC_DTYPES)
+def test_pandas_nullable_numeric_feature(dtype):
+    df = pd.DataFrame({'f': pd.Series(_nullable_numeric_series_values(dtype), dtype=dtype)})
+    pool = Pool(df)
+    _check_single_feature_values(pool.get_features(), _expected_numeric_feature_values(dtype))
+
+    y = [0, 1, 0, 1, 0, 1, 0, 1]
+    model = CatBoostRegressor(iterations=2, verbose=0).fit(df, y)
+    assert model.predict(df).shape == (len(y),)
+
+
+@requires_pandas_nullable_types
+def test_pandas_nullable_features_equivalent_to_nan():
+    n_objects = 100
+    rng = np.random.RandomState(0)
+    values = rng.randint(0, 100, n_objects)
+    na_mask = rng.rand(n_objects) < 0.3
+
+    def maybe_na(value, is_na):
+        return pd.NA if is_na else value
+
+    df_nullable = pd.DataFrame({
+        'int': pd.Series([maybe_na(int(v), m) for v, m in zip(values, na_mask)], dtype='Int64'),
+        'float': pd.Series(
+            [maybe_na(float(v) + 0.5, m) for v, m in zip(values, na_mask)],
+            dtype='Float64' if _PANDAS_VERSION >= (1, 2) else 'float64'
+        ),
+        'bool': pd.Series([maybe_na(bool(v % 2), m) for v, m in zip(values, na_mask)], dtype='boolean'),
+    })
+    df_float = pd.DataFrame({
+        'int': [np.nan if m else float(v) for v, m in zip(values, na_mask)],
+        'float': [np.nan if m else float(v) + 0.5 for v, m in zip(values, na_mask)],
+        'bool': [np.nan if m else float(v % 2) for v, m in zip(values, na_mask)],
+    })
+    y = rng.rand(n_objects)
+
+    params = dict(iterations=10, verbose=0, random_seed=0)
+    pred_nullable = CatBoostRegressor(**params).fit(df_nullable, y).predict(df_nullable)
+    pred_float = CatBoostRegressor(**params).fit(df_float, y).predict(df_float)
+    np.testing.assert_allclose(pred_nullable, pred_float, rtol=1e-5, atol=1e-6)
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('na_value', [pd.NA, pd.NaT])
+def test_pandas_na_like_values_in_object_feature(na_value):
+    df = pd.DataFrame({'f': pd.Series([1.5, na_value, 3.5, 2.5], dtype=object)})
+    pool = Pool(df)
+    _check_single_feature_values(pool.get_features(), [1.5, np.nan, 3.5, 2.5])
+
+    CatBoostRegressor(iterations=2, verbose=0).fit(df, [0, 1, 0, 1])
+
+
+@requires_pandas_nullable_types
+def test_pandas_na_in_list_data():
+    data = [[1.5], [pd.NA], [3.5], [2.5]]
+    pool = Pool(data)
+    _check_single_feature_values(pool.get_features(), [1.5, np.nan, 3.5, 2.5])
+
+    CatBoostRegressor(iterations=2, verbose=0).fit(data, [0, 1, 0, 1])
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', _PANDAS_NULLABLE_NUMERIC_DTYPES)
+def test_pandas_nullable_series_data(dtype):
+    data = pd.Series(_nullable_numeric_series_values(dtype), dtype=dtype)
+    pool = Pool(data)
+    _check_single_feature_values(pool.get_features(), _expected_numeric_feature_values(dtype))
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', _PANDAS_NULLABLE_NUMERIC_DTYPES)
+def test_pandas_nullable_label(dtype):
+    X = pd.DataFrame({'f': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+    if dtype == 'boolean':
+        y_values = [True, False, True, False, True, False]
+    else:
+        y_values = [1, 2, 3, 4, 5, 6]
+    y = pd.Series(y_values, dtype=dtype)
+
+    CatBoostClassifier(iterations=2, verbose=0).fit(X, y)
+    CatBoostRegressor(iterations=2, verbose=0).fit(X, y)
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', _PANDAS_NULLABLE_NUMERIC_DTYPES)
+def test_pandas_nullable_label_with_na(dtype):
+    X = pd.DataFrame({'f': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+    if dtype == 'boolean':
+        y_values = [True, False, pd.NA, False, True, False]
+    else:
+        y_values = [1, 2, pd.NA, 4, 5, 6]
+    y = pd.Series(y_values, dtype=dtype)
+
+    # missing values are not allowed in labels, but the error must be a CatBoostError
+    with pytest.raises(CatBoostError):
+        CatBoostClassifier(iterations=2, verbose=0).fit(X, y)
+    with pytest.raises(CatBoostError):
+        CatBoostRegressor(iterations=2, verbose=0).fit(X, y)
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', ['string', 'object'])
+def test_pandas_na_in_cat_feature(dtype):
+    df = pd.DataFrame({'f': pd.Series(['a', pd.NA, 'b', 'a'], dtype=dtype)})
+    with pytest.raises(CatBoostError, match='cat_features'):
+        Pool(df, cat_features=[0])
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', ['string', 'object'])
+def test_pandas_na_in_text_feature(dtype):
+    df = pd.DataFrame({'f': pd.Series(['a', pd.NA, 'b', 'a'], dtype=dtype)})
+    with pytest.raises(CatBoostError, match='text_features'):
+        Pool(df, text_features=[0])
+
+
+@requires_pandas_nullable_types
+def test_pandas_nullable_int_as_cat_feature():
+    df_ok = pd.DataFrame({'f': pd.Series([1, 2, 3, 1], dtype='Int64')})
+    Pool(df_ok, cat_features=[0])
+
+    df_na = pd.DataFrame({'f': pd.Series([1, pd.NA, 3, 1], dtype='Int64')})
+    with pytest.raises(CatBoostError, match='cat_features'):
+        Pool(df_na, cat_features=[0])
+
+
+@requires_pandas_nullable_types
+def test_pandas_nullable_predict():
+    rng = np.random.RandomState(0)
+    X_train = pd.DataFrame({'f': rng.rand(20)})
+    y = rng.rand(20)
+    model = CatBoostRegressor(iterations=2, verbose=0).fit(X_train, y)
+
+    X_nullable = pd.DataFrame({'f': pd.Series([1, pd.NA, 3], dtype='Int64')})
+    X_float = pd.DataFrame({'f': [1.0, np.nan, 3.0]})
+    np.testing.assert_allclose(model.predict(X_nullable), model.predict(X_float))
+
+
 def test_pandas_categorical_with_categories_as_string_array():
     X = pd.DataFrame({
         "ints": pd.Series([1, 9, 5]),

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -11188,6 +11188,188 @@ def test_pandas_integer_array():
     cb.fit(X, y)
 
 
+_PANDAS_VERSION = tuple(map(int, re.findall(r'\d+', pd.__version__)[:2]))
+
+_PANDAS_NULLABLE_INT_DTYPES = ['Int8', 'Int16', 'Int32', 'Int64', 'UInt8', 'UInt16', 'UInt32', 'UInt64']
+# nullable floating point extension dtypes are available only since pandas 1.2.0
+_PANDAS_NULLABLE_FLOAT_DTYPES = ['Float32', 'Float64'] if _PANDAS_VERSION >= (1, 2) else []
+_PANDAS_NULLABLE_NUMERIC_DTYPES = _PANDAS_NULLABLE_INT_DTYPES + _PANDAS_NULLABLE_FLOAT_DTYPES + ['boolean']
+
+requires_pandas_nullable_types = pytest.mark.skipif(
+    _PANDAS_VERSION < (1, 0),
+    reason='pandas nullable types and pandas.NA are available only since pandas 1.0.0'
+)
+
+
+def _nullable_numeric_series_values(dtype):
+    if dtype == 'boolean':
+        return [True, False, pd.NA, True, False, True, False, pd.NA]
+    return [1, 2, pd.NA, 4, 5, 6, 7, pd.NA]
+
+
+def _expected_numeric_feature_values(dtype):
+    if dtype == 'boolean':
+        return [1.0, 0.0, np.nan, 1.0, 0.0, 1.0, 0.0, np.nan]
+    return [1.0, 2.0, np.nan, 4.0, 5.0, 6.0, 7.0, np.nan]
+
+
+def _check_single_feature_values(features, expected):
+    assert features.shape == (len(expected), 1)
+    for got, want in zip(features[:, 0], expected):
+        if np.isnan(want):
+            assert np.isnan(got)
+        else:
+            assert got == want
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', _PANDAS_NULLABLE_NUMERIC_DTYPES)
+def test_pandas_nullable_numeric_feature(dtype):
+    df = pd.DataFrame({'f': pd.Series(_nullable_numeric_series_values(dtype), dtype=dtype)})
+    pool = Pool(df)
+    _check_single_feature_values(pool.get_features(), _expected_numeric_feature_values(dtype))
+
+    y = [0, 1, 0, 1, 0, 1, 0, 1]
+    model = CatBoostRegressor(iterations=2, verbose=0).fit(df, y)
+    assert model.predict(df).shape == (len(y),)
+
+
+@requires_pandas_nullable_types
+def test_pandas_nullable_features_equivalent_to_nan():
+    n_objects = 100
+    rng = np.random.RandomState(0)
+    values = rng.randint(0, 100, n_objects)
+    na_mask = rng.rand(n_objects) < 0.3
+
+    def maybe_na(value, is_na):
+        return pd.NA if is_na else value
+
+    df_nullable = pd.DataFrame({
+        'int': pd.Series([maybe_na(int(v), m) for v, m in zip(values, na_mask)], dtype='Int64'),
+        'float': pd.Series(
+            [maybe_na(float(v) + 0.5, m) for v, m in zip(values, na_mask)],
+            dtype='Float64' if _PANDAS_VERSION >= (1, 2) else 'float64'
+        ),
+        'bool': pd.Series([maybe_na(bool(v % 2), m) for v, m in zip(values, na_mask)], dtype='boolean'),
+    })
+    df_float = pd.DataFrame({
+        'int': [np.nan if m else float(v) for v, m in zip(values, na_mask)],
+        'float': [np.nan if m else float(v) + 0.5 for v, m in zip(values, na_mask)],
+        'bool': [np.nan if m else float(v % 2) for v, m in zip(values, na_mask)],
+    })
+    y = rng.rand(n_objects)
+
+    params = dict(iterations=10, verbose=0, random_seed=0)
+    pred_nullable = CatBoostRegressor(**params).fit(df_nullable, y).predict(df_nullable)
+    pred_float = CatBoostRegressor(**params).fit(df_float, y).predict(df_float)
+    np.testing.assert_allclose(pred_nullable, pred_float, rtol=1e-5, atol=1e-6)
+
+
+@requires_pandas_nullable_types
+def test_pandas_na_in_object_feature():
+    df = pd.DataFrame({'f': pd.Series([1.5, pd.NA, 3.5, 2.5], dtype=object)})
+    pool = Pool(df)
+    _check_single_feature_values(pool.get_features(), [1.5, np.nan, 3.5, 2.5])
+
+    CatBoostRegressor(iterations=2, verbose=0).fit(df, [0, 1, 0, 1])
+
+
+@requires_pandas_nullable_types
+def test_pandas_nat_in_object_feature_fails():
+    # pandas.NaT is designed for missing datetime data and is invalid in a numerical column
+    df = pd.DataFrame({'f': pd.Series([1.5, pd.NaT, 3.5, 2.5], dtype=object)})
+    with pytest.raises(CatBoostError):
+        Pool(df)
+
+
+@requires_pandas_nullable_types
+def test_pandas_na_in_list_data():
+    data = [[1.5], [pd.NA], [3.5], [2.5]]
+    pool = Pool(data)
+    _check_single_feature_values(pool.get_features(), [1.5, np.nan, 3.5, 2.5])
+
+    CatBoostRegressor(iterations=2, verbose=0).fit(data, [0, 1, 0, 1])
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', _PANDAS_NULLABLE_NUMERIC_DTYPES)
+def test_pandas_nullable_series_data(dtype):
+    data = pd.Series(_nullable_numeric_series_values(dtype), dtype=dtype)
+    pool = Pool(data)
+    _check_single_feature_values(pool.get_features(), _expected_numeric_feature_values(dtype))
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', _PANDAS_NULLABLE_NUMERIC_DTYPES)
+def test_pandas_nullable_label(dtype):
+    X = pd.DataFrame({'f': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+    if dtype == 'boolean':
+        y_values = [True, False, True, False, True, False]
+    else:
+        y_values = [1, 2, 3, 4, 5, 6]
+    y = pd.Series(y_values, dtype=dtype)
+
+    CatBoostClassifier(iterations=2, verbose=0).fit(X, y)
+    CatBoostRegressor(iterations=2, verbose=0).fit(X, y)
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', _PANDAS_NULLABLE_NUMERIC_DTYPES)
+def test_pandas_nullable_label_with_na(dtype):
+    X = pd.DataFrame({'f': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+    if dtype == 'boolean':
+        y_values = [True, False, pd.NA, False, True, False]
+    else:
+        y_values = [1, 2, pd.NA, 4, 5, 6]
+    y = pd.Series(y_values, dtype=dtype)
+
+    # missing values are not allowed in labels, but the error must be a CatBoostError
+    with pytest.raises(CatBoostError):
+        CatBoostClassifier(iterations=2, verbose=0).fit(X, y)
+    with pytest.raises(CatBoostError):
+        CatBoostRegressor(iterations=2, verbose=0).fit(X, y)
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', ['string', 'object'])
+def test_pandas_na_in_cat_feature(dtype):
+    df = pd.DataFrame({'f': pd.Series(['a', pd.NA, 'b', 'a'], dtype=dtype)})
+    with pytest.raises(TypeError):
+        Pool(df, cat_features=[0])
+
+
+@requires_pandas_nullable_types
+@pytest.mark.parametrize('dtype', ['string', 'object'])
+def test_pandas_na_in_text_feature(dtype):
+    df = pd.DataFrame({'f': pd.Series(['a', pd.NA, 'b', 'a'], dtype=dtype)})
+    with pytest.raises(CatBoostError, match='text_features'):
+        Pool(df, text_features=[0])
+
+
+@requires_pandas_nullable_types
+def test_pandas_nullable_int_as_cat_feature():
+    df_ok = pd.DataFrame({'f': pd.Series([1, 2, 3, 1], dtype='Int64')})
+    Pool(df_ok, cat_features=[0])
+
+    df_na = pd.DataFrame({'f': pd.Series([1, pd.NA, 3, 1], dtype='Int64')})
+    # pandas 2.x: to_numpy() gives an object array with pd.NA -> TypeError on conversion to int;
+    # pandas 3.x: to_numpy() gives a float64 array with NaN -> CatBoostError for float values
+    with pytest.raises((TypeError, CatBoostError)):
+        Pool(df_na, cat_features=[0])
+
+
+@requires_pandas_nullable_types
+def test_pandas_nullable_predict():
+    rng = np.random.RandomState(0)
+    X_train = pd.DataFrame({'f': rng.rand(20)})
+    y = rng.rand(20)
+    model = CatBoostRegressor(iterations=2, verbose=0).fit(X_train, y)
+
+    X_nullable = pd.DataFrame({'f': pd.Series([1, pd.NA, 3], dtype='Int64')})
+    X_float = pd.DataFrame({'f': [1.0, np.nan, 3.0]})
+    np.testing.assert_allclose(model.predict(X_nullable), model.predict(X_float))
+
+
 def test_pandas_categorical_with_categories_as_string_array():
     X = pd.DataFrame({
         "ints": pd.Series([1, 9, 5]),


### PR DESCRIPTION
Fixes #2037, related to #1645.

## Problem

pandas nullable extension dtypes (`Int8`..`Int64`, `UInt8`..`UInt64`, `Float32`, `Float64`, `boolean`, `string`) represent missing values with `pandas.NA` instead of `np.nan`. CatBoost failed on such data with cryptic errors:

```
TypeError: float() argument must be a string or a number, not 'NAType'
```

This happened for numeric features (e.g. `boolean` columns with `pd.NA`, object-dtype columns containing `pd.NA`, list input containing `pd.NA`) and for labels with nullable dtypes.

## Changes

**`catboost/python-package/catboost/_catboost.pyx`**
- `_FloatOrNan`: treat `pandas.NA` as NaN. This fixes all generic input paths: object-dtype DataFrame columns, list-of-lists input, `pandas.Series` as `data`, embedding features. `pandas.NaT` is intentionally **not** treated as a missing value: it is designed for missing datetime data only, so it remains an invalid input and raises an error, as before.
- `_set_features_order_data_pd_data_frame`: vectorized conversion of pandas nullable numeric/boolean extension dtypes to `float32` with NaN (`to_numpy(dtype=np.float32, na_value=np.nan)`) instead of slow per-element conversion. The `to_numpy()` conversion is now performed inside each feature-type branch with its own logic.

**`catboost/python-package/catboost/core.py`**
- `_label_if_pandas_to_numpy`: labels that are `pandas.Series` with nullable numeric/boolean dtypes are converted to `float64` with NaN. Nullable labels without missing values now work for both classification and regression; labels with missing values produce a clear `CatBoostError` from the C++ core (missing target values are not supported by CatBoost, same as `np.nan` before).

## Backward compatibility

- No behavior changes for previously working inputs. All numeric features are stored as `float32` internally, so the vectorized conversion is value-identical to the previous per-element path.
- `pandas.NA`/`pandas.NaT` in categorical features remain unsupported and fail with the same errors as before this change (missing values in categorical features are not supported — same semantics as `np.nan` before).
- Guards for old pandas versions: `pandas.NA` is looked up with `getattr` (it exists only since pandas 1.0.0); nullable floating dtypes exist only since pandas 1.2.0.

## Tests

Added 12 test functions (54 with parametrization) to `catboost/python-package/ut/medium/test.py`:
- all nullable numeric/boolean dtypes as features (Pool contents + fit + predict)
- equivalence of models trained on nullable data and on `float64` data with `np.nan`
- `pandas.NA` in object-dtype columns, list input and `pandas.Series` input
- `pandas.NaT` in a numerical column raises an error (behavior preserved)
- nullable labels with and without missing values
- NA values in categorical/text features raise errors

Tested with pandas 3.0.5 and pandas 2.3.3: all new tests pass, and the broader pool/pandas/label/dataframe-related test slice passes with no regressions.
