### PR TITLE
Explicitly declare zero-arg functions in C API

### DIFF
--- a/catboost/libs/model_interface/c_api.cpp
+++ b/catboost/libs/model_interface/c_api.cpp
@@ -260,7 +260,7 @@ CATBOOST_API DataProviderHandle* BuildDataProvider(DataWrapperHandle* dataWrappe
     return DATA_WRAPPER_PTR(dataWrapperHandle)->BuildDataProvider().Get();
 }
 
-CATBOOST_API ModelCalcerHandle* ModelCalcerCreate() {
+CATBOOST_API ModelCalcerHandle* ModelCalcerCreate(void) {
     try {
         auto* fullModel = new TFullModel;
         return new TModelHandleContent{.FullModel = THolder(fullModel)};
@@ -271,7 +271,7 @@ CATBOOST_API ModelCalcerHandle* ModelCalcerCreate() {
     return nullptr;
 }
 
-CATBOOST_API const char* GetErrorString() {
+CATBOOST_API const char* GetErrorString(void) {
     return ErrorMessageHolder.Get().Message.data();
 }
 

--- a/catboost/libs/model_interface/c_api.h
+++ b/catboost/libs/model_interface/c_api.h
@@ -65,7 +65,7 @@ enum ECatBoostApiFormulaEvaluatorType {
  * Create empty model handle
  * @return
  */
-CATBOOST_API ModelCalcerHandle* ModelCalcerCreate();
+CATBOOST_API ModelCalcerHandle* ModelCalcerCreate(void);
 
 /**
  * Delete model handle
@@ -81,7 +81,7 @@ CATBOOST_API void ModelCalcerDelete(ModelCalcerHandle* modelHandle);
  *  - indicates only errors that happened in the current thread
  * @return Error message string. Uses UTF-8 encoding
  */
-CATBOOST_API const char* GetErrorString();
+CATBOOST_API const char* GetErrorString(void);
 
 /**
  * Load model from file into given model handle


### PR DESCRIPTION
This fixes the invalid C API signatures which currently use `()` for no-arg functions, which actually means variadic number of arguments unlike the correct `(void)`.

This is not needed in C23, but this is not baseline of the project AFAIKS.

---

Before submitting a pull request, please do the following steps:

1. Read [instructions for contributors](https://catboost.ai/docs/concepts/development-and-contributions.html).
2. Make sure [the code builds](https://catboost.ai/en/docs/concepts/build-from-source).
3. If you add new functionality [add tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to check it.
4. [Run existing tests](https://catboost.ai/en/docs/concepts/development-and-contributions#run-tests) to make sure you haven't broken anything.
