### PR TITLE
Fix insufficient precision in tree split descriptions

### DIFF
--- a/catboost/private/libs/algo/tree_print.cpp
+++ b/catboost/private/libs/algo/tree_print.cpp
@@ -131,9 +131,9 @@ TString BuildDescription(const NCB::TFeaturesLayout& layout, const TSplit& featu
     result << BuildDescription(layout, static_cast<const TSplitCandidate&>(feature));
 
     if (feature.Type == ESplitType::OnlineCtr) {
-        result << ", border=" << feature.BinBorder;
+        result << ", border=" << FloatToString(feature.BinBorder);
     } else if ((feature.Type == ESplitType::FloatFeature) || (feature.Type == ESplitType::EstimatedFeature)) {
-        result << ", bin=" << feature.BinBorder;
+        result << ", bin=" << FloatToString(feature.BinBorder);
     } else {
         Y_ASSERT(feature.Type == ESplitType::OneHotFeature);
         result << ", value=" << feature.BinBorder;
@@ -164,11 +164,11 @@ TString BuildDescription(const NCB::TFeaturesLayout& layout, const TModelSplit& 
     }
 
     if (feature.Type == ESplitType::OnlineCtr) {
-        result << ", border=" << feature.OnlineCtr.Border;
+        result << ", border=" << FloatToString(feature.OnlineCtr.Border);
     } else if (feature.Type == ESplitType::FloatFeature) {
-        result << ", bin=" << feature.FloatFeature.Split;
+        result << ", bin=" << FloatToString(feature.FloatFeature.Split);
     } else if (feature.Type == ESplitType::EstimatedFeature) {
-        result << ", bin=" << feature.EstimatedFeature.Split;
+        result << ", bin=" << FloatToString(feature.EstimatedFeature.Split);
     } else {
         Y_ASSERT(feature.Type == ESplitType::OneHotFeature);
         result << ", value=";

--- a/catboost/private/libs/algo/tree_print.cpp
+++ b/catboost/private/libs/algo/tree_print.cpp
@@ -131,9 +131,9 @@ TString BuildDescription(const NCB::TFeaturesLayout& layout, const TSplit& featu
     result << BuildDescription(layout, static_cast<const TSplitCandidate&>(feature));
 
     if (feature.Type == ESplitType::OnlineCtr) {
-        result << ", border=" << FloatToString(feature.BinBorder);
+        result << ", border=" << feature.BinBorder;
     } else if ((feature.Type == ESplitType::FloatFeature) || (feature.Type == ESplitType::EstimatedFeature)) {
-        result << ", bin=" << FloatToString(feature.BinBorder);
+        result << ", bin=" << feature.BinBorder;
     } else {
         Y_ASSERT(feature.Type == ESplitType::OneHotFeature);
         result << ", value=" << feature.BinBorder;


### PR DESCRIPTION
Fixes #2415

`BuildDescription()` (used by `GetTreeSplitsDescriptions()`, which
backs `CatBoost._get_tree_splits()` / `plot_tree()`) formatted split
thresholds via `TStringBuilder`'s default float stream operator,
which truncates to 6 significant digits. This isn't enough to fully
specify a 32-bit float, so distinct but close split thresholds could
print identically and paths through the tree could no longer be
traced from the description alone.

Switches to `FloatToString()` (already used elsewhere in this file),
which defaults to `PREC_AUTO` and prints the shortest string that
round-trips back to the exact same float value.

### Other Information

I wasn't able to build/run the full test suite locally (didn't set
up the full CatBoost build environment) — the change follows the
same `FloatToString` pattern already used elsewhere in this file
(see line 246), so happy to iterate if CI or a maintainer flags
anything.