### PR TITLE
fix(python): informative error for null values in polars Categorical/Enum cat_features (#3106)

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -336,6 +336,27 @@ def _get_features_indices(features, feature_names):
     return features
 
 
+def _check_polars_categorical_features_have_no_nulls(data, cat_features):
+    """Raise an informative error for null values in polars Categorical/Enum cat_features.
+
+        Null values in categorical columns are not supported. For a polars.String column
+        (or for pandas) this is reported with a clear message, but for a polars.Enum or
+        polars.Categorical column the nulls used to reach the compiled layer and surface
+        as an opaque ``TypeError: No matching signature found`` (see issue #3106). Detect
+        the nulls here and report them the same way as the other backends.
+    """
+    if (not isinstance(data, pl.DataFrame)) or (not cat_features):
+        return
+    for feature_idx in cat_features:
+        dtype = data.dtypes[feature_idx]
+        if (dtype == pl.Categorical) or isinstance(dtype, pl.Enum):
+            if data.to_series(feature_idx).null_count() > 0:
+                raise CatBoostError(
+                    "Data with nulls is not supported for categorical columns, but categorical "
+                    "column '{}' contains null values".format(data.columns[feature_idx])
+                )
+
+
 def _update_params_quantize_part(params, ignored_features, per_float_feature_quantization, border_count,
                                  feature_border_type, sparse_features_conflict_fraction, dev_efb_max_buckets,
                                  nan_mode, input_borders, task_type, used_ram_limit, random_seed,
@@ -1471,6 +1492,7 @@ class Pool(_PoolBase):
             cat_features = _get_features_indices(cat_features, feature_names)
             self._check_string_feature_type(cat_features, 'cat_features')
             self._check_string_feature_value(cat_features, features_count, 'cat_features')
+            _check_polars_categorical_features_have_no_nulls(data, cat_features)
         if text_features is not None:
             text_features = _get_features_indices(text_features, feature_names)
             self._check_string_feature_type(text_features, 'text_features')


### PR DESCRIPTION
## What

Fixes #3106. When a `polars.Enum` or `polars.Categorical` column is passed as a `cat_feature` and it contains null values, `Pool` fails with an opaque, un-actionable error instead of the clear message the other data backends give.

## Why

Null values in categorical columns are not supported. The other paths say so clearly:

```python
# polars.String cat column with nulls:
#   (TCatBoostException) ... Data with nulls is not supported for categorical columns
# pandas cat column with nulls:
#   CatBoostError: Invalid type for cat_feature ...
```

But a `polars.Enum`/`polars.Categorical` cat column with nulls reaches the compiled layer and surfaces as:

```
TypeError: No matching signature found
  File "_catboost.pyx", line 3299, in _catboost._set_features_order_data_polars_categorical_column.process
```

…which gives the user nothing to localize the problem.

Reproduction (on `catboost==1.2.10`):

```python
import polars as pl
from catboost import Pool

df = pl.DataFrame({'x0':[1,2,3], 'cat0':['a', None, 'b'], 'y':[0,1,0]}).cast({'cat0': pl.Enum(['a','b'])})
Pool(df.drop('y'), df.select('y').to_series(), cat_features=['cat0'])
# TypeError: No matching signature found   ← unhelpful
```

## How

Add a small, pure-Python pre-validation (`_check_polars_categorical_features_have_no_nulls`) that runs after `cat_features` are resolved to indices. For a `polars.DataFrame`, it checks each `cat_feature` column that is `polars.Categorical`/`polars.Enum` and, if it contains nulls, raises a `CatBoostError` with the same intent as the existing backends, naming the offending column:

```
CatBoostError: Data with nulls is not supported for categorical columns, but categorical column 'cat0' contains null values
```

This aligns the polars Enum/Categorical path with the already-informative behavior of the polars-String and pandas paths, without changing what is (and isn't) supported. It only affects the error surfaced for an already-failing input; valid categorical columns (no nulls) are untouched.

## Verification

Tested against `catboost==1.2.10` with `polars==1.43.2`:

- `Enum` column with nulls → now raises the informative `CatBoostError` (was `TypeError: No matching signature found`).
- `Categorical` column with nulls → same informative `CatBoostError`.
- `Enum` column **without** nulls → `Pool` builds normally (no false positive).

The module `py_compile`s cleanly. I verified the behavior by applying the patch over the installed package; I did not add a case to the `ya make`-based test suite as it isn't runnable standalone — happy to add one in your preferred location/format if you'd like.

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*