### PR TITLE
Support scale and bias in SHAP values

### DIFF
--- a/catboost/libs/fstr/calc_fstr.cpp
+++ b/catboost/libs/fstr/calc_fstr.cpp
@@ -485,7 +485,7 @@ TVector<TVector<double>> GetFeatureImportances(
     if (dataset) {
         CheckModelAndDatasetCompatibility(model, *dataset->ObjectsData.Get());
     }
-    if (fstrType != EFstrType::PredictionValuesChange) {
+    if (fstrType != EFstrType::PredictionValuesChange && fstrType != EFstrType::ShapValues) {
         CB_ENSURE_SCALE_IDENTITY(model.GetScaleAndBias(), "feature importance");
     }
     switch (fstrType) {
@@ -653,4 +653,3 @@ TVector<TString> GetMaybeGeneratedModelFeatureIds(const TFullModel& model, const
     }
     return GetMaybeGeneratedModelFeatureIds(model, std::move(datasetFeaturesLayout));
 }
-

--- a/catboost/libs/fstr/independent_tree_shap.cpp
+++ b/catboost/libs/fstr/independent_tree_shap.cpp
@@ -328,11 +328,12 @@ static TVector<double> GetMeanValues(
     EExplainableModelOutput modelOutputType,
     double target,
     bool isNotRawOutputType,
+    double scale,
     double bias
 ) {
     TVector<double> meanValues(shapValues.size());
     for (size_t idx = 0; idx < shapValues.size(); ++idx) {
-        meanValues[idx] = shapValues[idx].back() + bias;
+        meanValues[idx] = shapValues[idx].back() * scale + bias;
     }
     if (!isNotRawOutputType) {
         return meanValues;
@@ -383,15 +384,18 @@ static TVector<double> GetUnpackedShapValues(
 
 static TVector<TVector<double>> GetProbabilityMeanValues(
     const TVector<TVector<TVector<double>>>& shapValues, // [refIdx][dim][feature]
-    const TVector<double>& bias
+    const TScaleAndBias& scaleAndBias
 ) {
+    const double scale = scaleAndBias.Scale;
+    const auto& bias = scaleAndBias.GetBiasRef();
     TVector<TVector<double>> probabilityMeanValues(shapValues[0].size(), TVector<double>(shapValues.size(), 0.0));
     for (auto referenceIdx : xrange(shapValues.size())) {
         const auto& shapValuesForReference = shapValues[referenceIdx];
         const size_t approxDimension = shapValuesForReference.size();
         TVector<double> meanValuesForReference(approxDimension);
         for (auto dimension : xrange(approxDimension)) {
-            meanValuesForReference[dimension] = shapValuesForReference[dimension].back() + bias[dimension];
+            meanValuesForReference[dimension] =
+                shapValuesForReference[dimension].back() * scale + bias[dimension];
         }
         TVector<double> probabilityMeanValuesForReference(approxDimension);
         CalcSoftmax(meanValuesForReference, &probabilityMeanValuesForReference);
@@ -410,9 +414,11 @@ void PostProcessingIndependent(
     size_t flatFeatureCount,
     size_t documentIdx,
     bool calcInternalValues,
-    const TVector<double>& bias,
+    const TScaleAndBias& scaleAndBias,
     TVector<TVector<double>>* shapValues
 ) {
+    const double scale = scaleAndBias.Scale;
+    const auto& bias = scaleAndBias.GetBiasRef();
     const size_t featureCount = calcInternalValues ? combinationClassFeatures.size() : flatFeatureCount;
     const size_t referenceCount = independentTreeShapParams.ReferenceLeafIndicesForAllTrees[0].size();
     EExplainableModelOutput modelOutputType = independentTreeShapParams.ModelOutputType;
@@ -425,7 +431,10 @@ void PostProcessingIndependent(
     const bool isExplainMultiClassProbabilities = approxDimension > 1 && EExplainableModelOutput::Probability == modelOutputType;
     TVector<TVector<double>> meanValuesProbabitiesForAllReference;
     if (isExplainMultiClassProbabilities) {
-        meanValuesProbabitiesForAllReference = GetProbabilityMeanValues(shapValuesInternalForAllReferences, bias);
+        meanValuesProbabitiesForAllReference = GetProbabilityMeanValues(
+            shapValuesInternalForAllReferences,
+            scaleAndBias
+        );
     }
     // prepare shap values for all references
     TVector<TVector<TVector<double>>> shapValuesForAllReferences(approxDimension);
@@ -464,6 +473,7 @@ void PostProcessingIndependent(
                 modelOutputType,
                 targetOfDocument,
                 isNotRawOutputType,
+                scale,
                 bias[dimension]
             );
         const auto& shapValuesForAllReferencesOneDimensional = shapValuesForAllReferences[dimension];
@@ -480,7 +490,8 @@ void PostProcessingIndependent(
             double totalCoeffient = transformedCoeffient / rescaleCoefficient;
             TConstArrayRef<double> shapValuesForReferenceOneDimensional = MakeConstArrayRef(shapValuesForAllReferencesOneDimensional[referenceIdx]);
             for (size_t featureIdx = 0; featureIdx < featureCount; ++featureIdx) {
-                shapValuesRef[featureIdx] += shapValuesForReferenceOneDimensional[featureIdx] * totalCoeffient;
+                shapValuesRef[featureIdx] +=
+                    shapValuesForReferenceOneDimensional[featureIdx] * scale * totalCoeffient;
             }
             shapValuesRef[featureCount] += (meanValues[referenceIdx] / rescaleCoefficient);
         }

--- a/catboost/libs/fstr/independent_tree_shap.h
+++ b/catboost/libs/fstr/independent_tree_shap.h
@@ -14,7 +14,7 @@ void PostProcessingIndependent(
     size_t flatFeatureCount,
     size_t documentIdx,
     bool calcInternalValues,
-    const TVector<double>& bias,
+    const TScaleAndBias& scaleAndBias,
     TVector<TVector<double>>* shapValues
 );
 

--- a/catboost/libs/fstr/shap_values.cpp
+++ b/catboost/libs/fstr/shap_values.cpp
@@ -1034,7 +1034,7 @@ void CalcShapValuesForDocumentMulti(
             }
         }
     }
-    const TVector<double>& bias = model.GetScaleAndBias().GetBiasRef();
+    const auto& scaleAndBias = model.GetScaleAndBias();
     if (isIndependent) {
         Y_ASSERT(independentTreeShapParams);
         PostProcessingIndependent(
@@ -1045,12 +1045,17 @@ void CalcShapValuesForDocumentMulti(
             featuresCount,
             documentIdx,
             preparedTrees.CalcInternalValues,
-            bias,
+            scaleAndBias,
             shapValues
         );
     } else {
         for (int dimension = 0; dimension < approxDimension; ++dimension) {
-            (*shapValues)[dimension][featuresCount] += bias[dimension];
+            for (int featureIdx = 0; featureIdx < featuresCount; ++featureIdx) {
+                (*shapValues)[dimension][featureIdx] *= scaleAndBias.Scale;
+            }
+            (*shapValues)[dimension][featuresCount] =
+                (*shapValues)[dimension][featuresCount] * scaleAndBias.Scale +
+                scaleAndBias.GetBiasRef()[dimension];
         }
     }
 }
@@ -1617,7 +1622,6 @@ void CalcAndOutputShapValues(
         calcType
     );
 
-    CB_ENSURE_SCALE_IDENTITY(model.GetScaleAndBias(), "SHAP values");
     const int flatFeatureCount = SafeIntegerCast<int>(dataset.MetaInfo.GetFeatureCount());
 
     const size_t documentCount = dataset.ObjectsGrouping->GetObjectCount();
@@ -1660,4 +1664,3 @@ void CalcAndOutputShapValues(
         documentsLogger.Log(profileResults);
     }
 }
-

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -4796,6 +4796,89 @@ def test_shap_feature_importance_modes(task_type, calc_shap_mode):
         assert np.all(np.abs(shaps_for_modes[i] - shaps_for_modes[i - 1]) < 1e-9)
 
 
+@pytest.mark.parametrize(
+    'calc_shap_mode, shap_calc_type',
+    [
+        ('TreeSHAP', 'Regular'),
+        ('TreeSHAP', 'Approximate'),
+        ('TreeSHAP', 'Exact'),
+        ('IndependentTreeSHAP', 'Regular'),
+    ],
+)
+@pytest.mark.parametrize('scale, bias', [(0.5, 1.25), (-0.75, -0.5), (0.0, 2.0)])
+def test_shap_feature_importance_with_scale_and_bias(calc_shap_mode, shap_calc_type, scale, bias):
+    pool = Pool(TRAIN_FILE, column_description=CD_FILE)
+    reference_data = make_reference_data(pool, calc_shap_mode)
+    model = CatBoostRegressor(iterations=5)
+    model.fit(pool)
+    scale_before, bias_before = model.get_scale_and_bias()
+    shap_values_before_scaling = np.array(
+        model.get_feature_importance(
+            type=EFstrType.ShapValues,
+            data=pool,
+            reference_data=reference_data,
+            shap_calc_type=shap_calc_type,
+        )
+    )
+
+    model.set_scale_and_bias(scale, bias)
+    shap_values = np.array(
+        model.get_feature_importance(
+            type=EFstrType.ShapValues,
+            data=pool,
+            reference_data=reference_data,
+            shap_calc_type=shap_calc_type,
+        )
+    )
+
+    scale_ratio = scale / scale_before
+    assert np.allclose(shap_values[:, :-1], shap_values_before_scaling[:, :-1] * scale_ratio)
+    assert np.allclose(
+        shap_values[:, -1],
+        (shap_values_before_scaling[:, -1] - bias_before) * scale_ratio + bias,
+    )
+    assert np.allclose(np.sum(shap_values, axis=1), model.predict(pool))
+
+
+def test_shap_feature_multiclass_probability_with_scale_and_bias():
+    pool = Pool(
+        [[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]],
+        [0, 1, 2, 0, 1, 2],
+    )
+    reference_data = pool.slice([0, 1, 2])
+    model = CatBoostClassifier(iterations=5, loss_function="MultiClass")
+    model.fit(pool)
+    model.set_scale_and_bias(0.5, [1.25, -0.75, 0.25])
+
+    shap_values = model.get_feature_importance(
+        type=EFstrType.ShapValues,
+        data=pool,
+        reference_data=reference_data,
+        model_output="Probability",
+    )
+    predictions = model.predict(pool, "Probability")
+
+    assert np.allclose(np.sum(shap_values, axis=2), predictions)
+
+
+def test_shap_feature_probability_with_scale_and_bias():
+    pool = Pool(TRAIN_FILE, column_description=CD_FILE)
+    reference_data = make_reference_data(pool, "IndependentTreeSHAP")
+    model = CatBoostClassifier(iterations=5)
+    model.fit(pool)
+    model.set_scale_and_bias(0.5, 1.25)
+
+    shap_values = model.get_feature_importance(
+        type=EFstrType.ShapValues,
+        data=pool,
+        reference_data=reference_data,
+        model_output="Probability",
+    )
+    predictions = model.predict(pool, "Probability")[:, 1]
+
+    assert np.allclose(np.sum(shap_values, axis=1), predictions)
+
+
 def test_shap_feature_probability(task_type):
     pool = Pool(TRAIN_FILE, column_description=CD_FILE)
     reference_data = make_reference_data(pool, "IndependentTreeSHAP")


### PR DESCRIPTION
## Summary

- allow SHAP values to be calculated for models with non-identity scale and bias
- scale feature contributions and apply the full affine transformation to expected values
- preserve additivity for regular, approximate, exact, and independent TreeSHAP, including probability outputs

For a transformed raw prediction `f_new(x) = scale * f(x) + bias`, each feature contribution is multiplied by `scale`, while the expected value is multiplied by `scale` and then shifted by `bias`. Independent TreeSHAP applies the same scale before its probability or loss transformation so that the SHAP values continue to sum to the requested model output.

Fixes #2389.

## Testing

- `python setup.py build --no-widget --no-cuda --parallel=8`
- targeted Python SHAP regression suite: 18 passed
- coverage includes positive, negative, and zero scales; Regular, Approximate, Exact, and Independent TreeSHAP; binary and multiclass probability outputs; and existing probability/loss additivity tests