### PR TITLE
Add exported-model code tests to CI

### DIFF
--- a/.github/workflows/test_per_platform.yaml
+++ b/.github/workflows/test_per_platform.yaml
@@ -282,6 +282,10 @@ jobs:
           Set-Location -LiteralPath ${{ github.workspace }}/catboost/catboost/pytest
           python -m pytest -n auto
 
+          $Env:TEST_OUTPUT_DIR = Join-Path ${{ github.workspace }} test_output_model_export
+          Set-Location -LiteralPath ${{ github.workspace }}/catboost/catboost/libs/model/model_export/ut
+          python -m pytest -n auto
+
       - name: Run python package tests
         shell: pwsh
         run: |
@@ -353,4 +357,3 @@ jobs:
 
           Rscript -e "install.packages('remotes', Ncpus = parallel::detectCores()); remotes::install_local('catboost_R_package/catboost-R-darwin-universal2.tgz', INSTALL_opts = c('--no-multiarch', '--no-staged-install', '--install-tests'))"
           Rscript -e "install.packages(c('testthat','caret','tibble'), Ncpus = parallel::detectCores()); testthat::test_package('catboost')"
-

--- a/catboost/libs/model/model_export/ut/test.py
+++ b/catboost/libs/model/model_export/ut/test.py
@@ -1,7 +1,6 @@
 import numpy as np
 import os
 import pytest
-import re
 import yatest
 
 from catboost import Pool, CatBoost, CatBoostClassifier
@@ -122,7 +121,7 @@ def test_cpp_export(dataset, parameters):
         yatest.common.execute(calc_cmd)
         yatest.common.execute(compare_cmd)
     except OSError as e:
-        if re.search(r"No such file or directory.*'{}'".format(re.escape(compile_cmd[0])), str(e)):
+        if isinstance(e, FileNotFoundError) and e.filename == compile_cmd[0]:
             pytest.xfail(reason='We ignore `compiler not found` error: {}\n'.format(str(e)))
         else:
             raise


### PR DESCRIPTION
Title: Add exported-model code tests to CI

## Summary

- Run the existing `catboost/libs/model/model_export/ut` pytest suite in the per-platform test workflow.
- Reuse the CLI, comparison tool, installed Python wheel, and yatest paths already prepared by the workflow.
- Give the suite a dedicated test output directory.

Fixes #3173

## Test evidence

- Parsed `.github/workflows/test_per_platform.yaml` with PyYAML.
- Ran a focused assertion that the artifact-backed pytest step contains the model-export suite invocation and dedicated output path.
- Compiled the suite's Python test and fixture sources with `python3 -m py_compile`.
- Ran `git diff --check`.

## Risks or notes for maintainers

The suite itself was not runnable in the isolated worktree because it requires the CI-built CatBoost CLI and comparison tool. The CI job already downloads those artifacts and supplies the compiler, wheel, source path, and binary path consumed by this suite. This adds suite runtime to each platform test job.
