### PR TITLE
Use system allocator for macOS Python package

### DIFF
--- a/catboost/python-package/catboost/CMakeLists.darwin-arm64.txt
+++ b/catboost/python-package/catboost/CMakeLists.darwin-arm64.txt
@@ -80,10 +80,6 @@ target_link_libraries(_catboost PUBLIC
   libs-gpu_config-maybe_have_cuda
 )
 
-target_allocator(_catboost
-  cpp-malloc-mimalloc
-)
-
 target_link_options(_catboost PRIVATE
   -headerpad_max_install_names
   -Wl,-platform_version,macos,11.0,11.0

--- a/catboost/python-package/catboost/CMakeLists.darwin-x86_64.txt
+++ b/catboost/python-package/catboost/CMakeLists.darwin-x86_64.txt
@@ -80,10 +80,6 @@ target_link_libraries(_catboost PUBLIC
   libs-gpu_config-maybe_have_cuda
 )
 
-target_allocator(_catboost
-  cpp-malloc-mimalloc
-)
-
 target_link_options(_catboost PRIVATE
   -headerpad_max_install_names
   -Wl,-platform_version,macos,11.0,11.0

--- a/catboost/python-package/catboost/no_cuda/CMakeLists.darwin-arm64.txt
+++ b/catboost/python-package/catboost/no_cuda/CMakeLists.darwin-arm64.txt
@@ -78,10 +78,6 @@ target_link_libraries(_catboost_no_cuda PUBLIC
   cpp-text_processing-app_helpers
 )
 
-target_allocator(_catboost_no_cuda
-  cpp-malloc-mimalloc
-)
-
 target_link_options(_catboost_no_cuda PRIVATE
   -headerpad_max_install_names
   -Wl,-platform_version,macos,11.0,11.0

--- a/catboost/python-package/catboost/no_cuda/CMakeLists.darwin-x86_64.txt
+++ b/catboost/python-package/catboost/no_cuda/CMakeLists.darwin-x86_64.txt
@@ -78,10 +78,6 @@ target_link_libraries(_catboost_no_cuda PUBLIC
   cpp-text_processing-app_helpers
 )
 
-target_allocator(_catboost_no_cuda
-  cpp-malloc-mimalloc
-)
-
 target_link_options(_catboost_no_cuda PRIVATE
   -headerpad_max_install_names
   -Wl,-platform_version,macos,11.0,11.0


### PR DESCRIPTION

Fixes #3086.

## Summary

Importing CatBoost's Python extension on macOS currently registers mimalloc as the process-wide default malloc zone. This can cause crashes when another native extension, such as PyTorch, is loaded in the same process and frees memory through a different allocator.

This change stops linking mimalloc into the macOS Python extension and lets the process continue using the system allocator. It covers the arm64 and x86_64 targets, including the no-CUDA variants. Other platforms are unchanged.

## Testing

- Built the no-CUDA macOS arm64 Python package with Python 3.12 and Python 3.13.
- Built the required `limited_precision_dsv_diff`, `limited_precision_json_diff`, and `model_comparator` targets.
- Verified that the resulting extension does not contain mimalloc symbols.
- Verified that importing CatBoost no longer changes the process's malloc zone count.
- Re-ran the original CatBoost and PyTorch reproducer; `torch.linalg.cholesky` completed successfully.
- Ran the complete Python package test suite on CPU: 6,381 passed, 148 skipped, and 272 expected failures.
