### PR TITLE
Remove two statements that assign a value to itself

### DIFF
--- a/catboost/libs/metrics/metric.cpp
+++ b/catboost/libs/metrics/metric.cpp
@@ -935,7 +935,6 @@ TMetricHolder TCoxMetric::Eval(
 
         lastExpP = expP;
     }
-    error.Stats[0] = error.Stats[0];
 
     return error;
 }

--- a/catboost/private/libs/quantized_pool_analysis/quantized_pool_analysis.cpp
+++ b/catboost/private/libs/quantized_pool_analysis/quantized_pool_analysis.cpp
@@ -361,7 +361,6 @@ namespace NCB {
             if (numObjs == 0) {
                 continue;
             }
-            countObjectsPerBin[binNum] = countObjectsPerBin[binNum];
             meanTarget[binNum] /= static_cast<float>(numObjs);
             meanPrediction[binNum] /= static_cast<float>(numObjs);
 


### PR DESCRIPTION
`TCoxMetric::Eval` ends with `error.Stats[0] = error.Stats[0];` and the per-bin loop in `quantized_pool_analysis.cpp` has `countObjectsPerBin[binNum] = countObjectsPerBin[binNum];` right where its neighbours divide by `numObjs`. Neither line does anything, and the second one reads as if the count was meant to be normalised too, which it isn't.
