### PR TITLE
fix(python): tolerate empty stack in _CustomLoggersStack.pop()

### DIFF
--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -182,7 +182,11 @@ class _CustomLoggersStack(object):
                 # because push from other threads does nothing
                 return
             if not self._stack:
-                raise RuntimeError('Attempt to pop from an empty stack')
+                # push() can be a no-op when another thread owns the stack
+                # (see push()), so push/pop are not guaranteed to be balanced
+                # when fit() runs concurrently from multiple threads. Popping
+                # an empty stack is therefore not an error.
+                return
 
             _reset_logger()
             if len(self._stack) != 1:

--- a/catboost/python-package/ut/small/test_core.py
+++ b/catboost/python-package/ut/small/test_core.py
@@ -1,0 +1,31 @@
+import threading
+
+from catboost.core import _CustomLoggersStack
+
+
+def test_custom_loggers_stack_push_pop_balance():
+    # A single-threaded push/pop pair, including reentrancy, must be balanced
+    # and must not raise.
+    stack = _CustomLoggersStack()
+    stack.push()
+    stack.push()
+    stack.pop()
+    stack.pop()
+
+
+def test_custom_loggers_stack_pop_on_empty_is_noop():
+    # Under concurrent fit() from multiple threads, push() can be a no-op
+    # (it returns early when another thread owns the stack), so push/pop are
+    # not guaranteed to be balanced. Popping an empty stack must be a no-op
+    # rather than raising, otherwise parallel fit() crashes with
+    # "RuntimeError: Attempt to pop from an empty stack" (see #2620).
+    stack = _CustomLoggersStack()
+    stack.push()
+    stack.pop()
+
+    # Reproduce the state that triggers the crash: the current thread is
+    # recorded as the owning thread, but the stack is empty.
+    stack._owning_thread_id = threading.current_thread().ident
+    stack._stack = []
+
+    stack.pop()


### PR DESCRIPTION
## Problem

Running `fit()` concurrently from multiple threads (e.g. `joblib.Parallel(..., prefer="threads")` or Optuna with `n_jobs>1`) intermittently crashes with:

```
RuntimeError: Attempt to pop from an empty stack
```

Reported in #2620. The global `_custom_loggers_stack` is shared across threads, and `log_fixup` wraps `fit()` (and other training entry points). `push()` already documents that it is a no-op when another thread owns the stack:

```python
def push(self, log_cout=None, log_cerr=None):
    with self._lock:
        if not self._stack:
            self._owning_thread_id = threading.current_thread().ident
        elif self._owning_thread_id != threading.current_thread().ident:
            ...
            return  # <-- no push, but log_fixup's `finally` still calls pop()
```

Because a thread can enter `log_fixup` without ever pushing onto the stack, `push()`/`pop()` are not guaranteed to be balanced. When such a thread later becomes the "owning" thread with an empty stack, `pop()` raised the invariant error.

## Fix

Make `pop()` treat an empty stack as a no-op, consistent with the existing no-op behavior for cross-thread pops:

```python
if not self._stack:
    # push() can be a no-op when another thread owns the stack (see push()),
    # so push/pop are not guaranteed to be balanced when fit() runs
    # concurrently from multiple threads. Popping an empty stack is
    # therefore not an error.
    return
```

## Test

Added `catboost/python-package/ut/small/test_core.py`:

- `test_custom_loggers_stack_push_pop_balance` — reentrant push/pop stays balanced.
- `test_custom_loggers_stack_pop_on_empty_is_noop` — reproduces the "owning thread + empty stack" state and asserts `pop()` no longer raises.

Both pass, and a smoke single-threaded `CatBoostRegressor.fit()` still works.