### PR TITLE
Fix plotly >= 7.0 compatibility (drop removed show_link option)

### DIFF
--- a/catboost/python-package/catboost/plot_helpers.py
+++ b/catboost/python-package/catboost/plot_helpers.py
@@ -43,7 +43,6 @@ def save_plot_file(plot_file, plot_name, figs):
             graph_div = plotly_plot(
                 fig,
                 output_type='div',
-                show_link=False,
                 include_plotlyjs=False
             )
             plot_file_stream.write('\n{}\n'.format(graph_div))

--- a/catboost/python-package/setup.py
+++ b/catboost/python-package/setup.py
@@ -790,7 +790,7 @@ if __name__ == '__main__':
             'numpy (>=1.16.0, <3.0)',
             'pandas (>=0.24, <4.0)',
             'scipy',
-            'plotly (<7.0)',
+            'plotly (<8.0)',
             'six',
         ],
         zip_safe=False,

--- a/catboost/python-package/ut/small/test_plot_helpers.py
+++ b/catboost/python-package/ut/small/test_plot_helpers.py
@@ -1,0 +1,22 @@
+import io
+from unittest import mock
+
+import pytest
+
+
+def test_save_plot_file_plotly_7_compat():
+    # plotly 7.x removed the `show_link` option from `plotly.offline.plot`,
+    # so `save_plot_file` must not pass it (see GH issue #3160).
+    pytest.importorskip("plotly.offline")
+
+    from catboost.plot_helpers import save_plot_file
+
+    buf = io.StringIO()
+    fig = {"data": [], "layout": {}}
+    with mock.patch("plotly.offline.plot", return_value="<div></div>") as mocked_plot:
+        save_plot_file(buf, "test-plot", [fig])
+
+    kwargs = mocked_plot.call_args.kwargs
+    assert "show_link" not in kwargs
+    assert kwargs["output_type"] == "div"
+    assert kwargs["include_plotlyjs"] is False


### PR DESCRIPTION
Fixes #3160.

## Problem

plotly 7.0 removed the `show_link` option from `plotly.offline.plot`, so `save_plot_file` (in `plot_helpers.py`) raised a `TypeError` when rendering a chart. The dependency pin `plotly (<7.0)` also prevented installing catboost alongside plotly 7.x.

## Change

- Removed the now-invalid `show_link=False` argument from the `plotly.offline.plot` call in `plot_helpers.py`. `output_type='div'` and `include_plotlyjs=False` are preserved (verified against plotly 7.0.0).
- Relaxed the dependency pin from `plotly (<7.0)` to `plotly (<8.0)` since the code is now compatible with 7.x.

## Test

Added `ut/small/test_plot_helpers.py` — `test_save_plot_file_plotly_7_compat` asserts `save_plot_file` calls `plotly.offline.plot` without `show_link`, with `output_type='div'` and `include_plotlyjs=False`. Skips if plotly is not installed.