### PR TITLE
Fix JNI local reference leak in RethrowExceptionFromJavaToCpp. Fix #3190

### DIFF
--- a/library/cpp/jni/jni.cpp
+++ b/library/cpp/jni/jni.cpp
@@ -111,12 +111,12 @@ void RethrowExceptionFromJavaToCpp() {
         env->ExceptionClear();
         auto excClass = TLocalClassRef(env->GetObjectClass(exc.Get()));
         jmethodID getMessage = env->GetMethodID(excClass.Get(), "getMessage", "()Ljava/lang/String;");
-        auto message = static_cast<jstring>(env->CallObjectMethod(exc.Get(), getMessage));
+        auto message = TLocalStringRef(static_cast<jstring>(env->CallObjectMethod(exc.Get(), getMessage)));
         std::string exceptionMsg = "<no message>";
         if (message) {
-            char const* msg = env->GetStringUTFChars(message, nullptr);
+            char const* msg = env->GetStringUTFChars(message.Get(), nullptr);
             exceptionMsg = msg;
-            env->ReleaseStringUTFChars(message, msg);
+            env->ReleaseStringUTFChars(message.Get(), msg);
         }
         THROW(TJniException().append(exceptionMsg));
     }


### PR DESCRIPTION
Fixes #3190

### Problem

In `library/cpp/jni/jni.cpp`, `RethrowExceptionFromJavaToCpp()` wraps the exception object (`exc`) and its class (`excClass`) in the RAII types `TLocalRef` / `TLocalClassRef`, so their JNI local references are deleted automatically on destruction. However, the exception's `getMessage()` result (`message`) was captured as a raw `jstring` with no RAII wrapper:

```cpp
auto message = static_cast<jstring>(env->CallObjectMethod(exc.Get(), getMessage));
```

`GetStringUTFChars` / `ReleaseStringUTFChars` only manage the UTF-8 byte buffer copy — they do not release the JNI local reference table entry for `message` itself. As a result, one local reference was leaked per converted Java exception. `TLocalStringRef` already exists in `jni.h` and is used elsewhere in the file (e.g. `NewStringUTF`), but wasn't applied here.

### Fix

Wrap `message` in `TLocalStringRef`, matching the existing pattern used for `exc` and `excClass`, so the local reference is deleted automatically on both the throw path and a normal return.

```diff
-        auto message = static_cast<jstring>(env->CallObjectMethod(exc.Get(), getMessage));
+        auto message = TLocalStringRef(static_cast<jstring>(env->CallObjectMethod(exc.Get(), getMessage)));
         std::string exceptionMsg = "<no message>";
         if (message) {
-            char const* msg = env->GetStringUTFChars(message, nullptr);
+            char const* msg = env->GetStringUTFChars(message.Get(), nullptr);
             exceptionMsg = msg;
-            env->ReleaseStringUTFChars(message, msg);
+            env->ReleaseStringUTFChars(message.Get(), msg);
         }
```

### Behavior change

None. This is a pure reference-lifetime fix:
- `if (message)` still resolves via `TLocalStringRef::operator bool()`, identical to the previous raw-pointer truthiness check.
- The exception message content, `TJniException` construction, and `THROW` logic are all unchanged.
- `message` is not used or referenced anywhere outside this block, so switching its lifetime management has no downstream effect.

### Testing

`library/cpp/jni` has no dedicated C++ unit test runner; JNI behavior is exercised through the JVM package tests (`catboost4j-prediction` / `catboost4j-spark`) in CI. Since this change has no observable behavior difference, no new test was added — consistent with the conventions in this part of the codebase.

### Diff stat

```
library/cpp/jni/jni.cpp | 6 +++---
1 file changed, 3 insertions(+), 3 deletions(-)
```