### PR TITLE
Fix GPU crash with MVS bootstrap and non-symmetric trees, abort in SHAP calculation and best split selection hardening (#1935)

### DIFF
--- a/catboost/cuda/methods/greedy_subsets_searcher.h
+++ b/catboost/cuda/methods/greedy_subsets_searcher.h
@@ -70,10 +70,12 @@ namespace NCatboostCuda {
 
         template <class TTarget,
                   class TDataSet>
-        TGreedyTreeLikeStructureSearcher<TTreeModel> CreateStructureSearcher(double randomStrengthMult, const TAdditiveModel<TResultModel>& /*result*/) {
+        TGreedyTreeLikeStructureSearcher<TTreeModel> CreateStructureSearcher(double randomStrengthMult, const TAdditiveModel<TResultModel>& result) {
             TTreeStructureSearcherOptions options = StructureSearcherOptions;
-            Y_ASSERT(options.BootstrapOptions.GetBootstrapType() != EBootstrapType::MVS);
             options.RandomStrength *= randomStrengthMult;
+            if (options.BootstrapOptions.GetBootstrapType() == EBootstrapType::MVS) {
+                options.MvsLambda = result.GetL1LeavesSum();
+            }
             return TGreedyTreeLikeStructureSearcher<TTreeModel>(FeaturesManager, options);
         }
 

--- a/catboost/cuda/methods/greedy_subsets_searcher/greedy_search_helper.cpp
+++ b/catboost/cuda/methods/greedy_subsets_searcher/greedy_search_helper.cpp
@@ -285,10 +285,12 @@ namespace NCudaLib {
 namespace NCatboostCuda {
     static TOptimizationTarget ComputeTarget(EScoreFunction scoreFunction,
                                              const NCatboostOptions::TBootstrapConfig& bootstrapConfig,
+                                             TMaybe<float> mvsLambda,
                                              const IWeakObjective& objective) {
         const bool isSecondOrderScoreFunction = IsSecondOrderScoreFunction(scoreFunction);
         TOptimizationTarget target;
         objective.StochasticDer(bootstrapConfig,
+                                mvsLambda,
                                 isSecondOrderScoreFunction,
                                 &target);
         return target;
@@ -380,6 +382,7 @@ namespace NCatboostCuda {
     TPointsSubsets TGreedySearchHelper::CreateInitialSubsets(const IWeakObjective& objective) {
         auto target = ComputeTarget(Options.ScoreFunction,
                                     Options.BootstrapOptions,
+                                    Options.MvsLambda,
                                     objective);
         if (Options.RandomStrength) {
             ScoreStdDev = Options.RandomStrength * ComputeTargetStdDev(target);

--- a/catboost/cuda/methods/greedy_subsets_searcher/structure_searcher_options.h
+++ b/catboost/cuda/methods/greedy_subsets_searcher/structure_searcher_options.h
@@ -22,5 +22,8 @@ namespace NCatboostCuda {
 
         double MinLeafSize = 1;
         double RandomStrength = 0;
+
+        // regularization for MVS bootstrap when mvs_reg is not set explicitly (L1 leaves sum of the previous tree)
+        TMaybe<float> MvsLambda;
     };
 }

--- a/catboost/cuda/methods/greedy_subsets_searcher/weak_objective_impl.h
+++ b/catboost/cuda/methods/greedy_subsets_searcher/weak_objective_impl.h
@@ -3,6 +3,8 @@
 #include <catboost/cuda/gpu_data/bootstrap.h>
 #include <catboost/cuda/targets/weak_objective.h>
 
+#include <util/generic/xrange.h>
+
 namespace NCatboostCuda {
     template <class TTargetFunc>
     class TWeakObjective: public IWeakObjective, public TMoveOnly {
@@ -19,15 +21,20 @@ namespace NCatboostCuda {
         }
 
         void StochasticDer(const NCatboostOptions::TBootstrapConfig& bootstrapConfig,
+                           TMaybe<float> mvsLambda,
                            bool secondDerAsWeights,
                            TOptimizationTarget* targetDer) const final {
+            if (bootstrapConfig.GetBootstrapType() == EBootstrapType::MVS) {
+                MvsStochasticDer(bootstrapConfig, mvsLambda, secondDerAsWeights, targetDer);
+                return;
+            }
+
             TGpuAwareRandom& random = Target.GetRandom();
 
             auto samplesMapping = Target.GetTarget().GetSamplesMapping();
             TStripeBuffer<float> sampledWeights;
             TStripeBuffer<ui32> sampledIndices;
 
-            Y_ASSERT(bootstrapConfig.GetBootstrapType() != EBootstrapType::MVS);
             const bool isContinuousIndices = TBootstrap<NCudaLib::TStripeMapping>::BootstrapAndFilter(
                 bootstrapConfig,
                 random,
@@ -51,6 +58,83 @@ namespace NCatboostCuda {
 
         TGpuAwareRandom& GetRandom() const {
             return Target.GetRandom();
+        }
+
+    private:
+        /* MVS sampling probabilities depend on the derivatives, so derivatives are computed for all samples first,
+         * then the bootstrap weights are applied and samples with zero weights are filtered out
+         * (the same as TBootstrap::BootstrapAndFilter does for oblivious trees).
+         */
+        void MvsStochasticDer(const NCatboostOptions::TBootstrapConfig& bootstrapConfig,
+                              TMaybe<float> mvsLambda,
+                              bool secondDerAsWeights,
+                              TOptimizationTarget* targetDer) const {
+            TGpuAwareRandom& random = Target.GetRandom();
+            auto samplesMapping = Target.GetTarget().GetSamplesMapping();
+
+            TStripeBuffer<float> unitWeights;
+            unitWeights.Reset(samplesMapping);
+            FillBuffer(unitWeights, 1.0f);
+
+            TStripeBuffer<ui32> allIndices;
+            allIndices.Reset(samplesMapping);
+            MakeSequence(allIndices);
+
+            Target.StochasticDer(std::move(unitWeights),
+                                 std::move(allIndices),
+                                 secondDerAsWeights,
+                                 targetDer);
+
+            auto& stats = targetDer->StatsToAggregate;
+            const ui32 statsCount = static_cast<ui32>(stats.GetColumnCount());
+            // column 0 is weights (or second derivatives), other columns are derivatives
+            CB_ENSURE(statsCount == 2, "MVS bootstrap is not supported for multidimensional targets on GPU");
+
+            TStripeBuffer<float> ders;
+            ders.Reset(stats.GetMapping());
+            {
+                auto dersView = stats.ColumnView(1);
+                ders.Copy(dersView);
+            }
+
+            TMaybe<float> lambda = bootstrapConfig.GetMvsReg();
+            if (!lambda.Defined()) {
+                lambda = mvsLambda;
+            }
+
+            TStripeBuffer<float> bootstrappedWeights;
+            bootstrappedWeights.Reset(stats.GetMapping());
+            TBootstrap<NCudaLib::TStripeMapping>::Bootstrap(bootstrapConfig,
+                                                            random,
+                                                            bootstrappedWeights,
+                                                            lambda,
+                                                            &ders);
+
+            for (auto column : xrange(statsCount)) {
+                auto columnView = stats.ColumnView(column);
+                MultiplyVector(columnView, bootstrappedWeights);
+            }
+
+            TStripeBuffer<ui32> nzIndices;
+            FilterZeroEntries(&bootstrappedWeights, &nzIndices);
+
+            CATBOOST_DEBUG_LOG << "Sampled docs count " << nzIndices.GetObjectsSlice().Size() << Endl;
+
+            TStripeBuffer<float> sampledStats;
+            sampledStats.Reset(nzIndices.GetMapping(), statsCount);
+            for (auto column : xrange(statsCount)) {
+                auto srcView = stats.ColumnView(column);
+                auto dstView = sampledStats.ColumnView(column);
+                Gather(dstView, srcView, nzIndices);
+            }
+
+            TStripeBuffer<ui32> sampledIndices;
+            sampledIndices.Reset(nzIndices.GetMapping());
+            Gather(sampledIndices, targetDer->Indices, nzIndices);
+
+            targetDer->StatsToAggregate = std::move(sampledStats);
+            targetDer->Indices = std::move(sampledIndices);
+            targetDer->IsContinuousIndices = false;
         }
 
     private:

--- a/catboost/cuda/models/bin_optimized_model.h
+++ b/catboost/cuda/models/bin_optimized_model.h
@@ -2,7 +2,30 @@
 
 #include <catboost/cuda/gpu_data/doc_parallel_dataset.h>
 
+#include <util/generic/array_ref.h>
+#include <util/generic/maybe.h>
+#include <util/generic/xrange.h>
+#include <util/generic/ymath.h>
+
 namespace NCatboostCuda {
+    // squared mean of L2 norms of leaf values, used as the default MVS regularization (mvs_reg)
+    inline TMaybe<float> CalcL1LeavesSum(TConstArrayRef<float> leafValues, ui32 dim) {
+        if (leafValues.empty()) {
+            return Nothing();
+        }
+        const auto numLeaves = leafValues.size() / dim;
+        double sumOverLeaves = 0;
+        for (auto leaf : xrange(numLeaves)) {
+            double w2 = 0;
+            for (auto d : xrange(dim)) {
+                const double leafValue = leafValues[dim * leaf + d];
+                w2 += leafValue * leafValue;
+            }
+            sumOverLeaves += sqrt(w2);
+        }
+        return Sqr(sumOverLeaves / numLeaves);
+    }
+
     class IBinOptimizedModel {
     public:
         virtual ~IBinOptimizedModel() {

--- a/catboost/cuda/models/non_symmetric_tree.h
+++ b/catboost/cuda/models/non_symmetric_tree.h
@@ -169,6 +169,10 @@ namespace NCatboostCuda {
             return LeafValues;
         }
 
+        TMaybe<float> GetL1LeavesSum() const {
+            return CalcL1LeavesSum(LeafValues, Dim);
+        }
+
         const TVector<double>& GetWeights() const {
             return LeafWeights;
         }

--- a/catboost/cuda/models/oblivious_model.h
+++ b/catboost/cuda/models/oblivious_model.h
@@ -170,20 +170,7 @@ namespace NCatboostCuda {
         }
 
         TMaybe<float> GetL1LeavesSum() const {
-            if (LeafValues.empty()) {
-                return Nothing();
-            }
-            const auto numLeaves = LeafValues.size() / Dim;
-            double sumOverLeaves = 0;
-            for (auto leaf : xrange(numLeaves)) {
-                double w2 = 0;
-                for (auto dim : xrange(Dim)) {
-                    const double leafValue = LeafValues[Dim * leaf + dim];
-                    w2 += leafValue * leafValue;
-                }
-                sumOverLeaves += sqrt(w2);
-            }
-            return Sqr(sumOverLeaves / numLeaves);
+            return CalcL1LeavesSum(LeafValues, Dim);
         }
 
         Y_SAVELOAD_DEFINE(ModelStructure, LeafValues, LeafWeights, Dim);

--- a/catboost/cuda/models/region_model.h
+++ b/catboost/cuda/models/region_model.h
@@ -84,6 +84,10 @@ namespace NCatboostCuda {
             return LeafValues;
         }
 
+        TMaybe<float> GetL1LeavesSum() const {
+            return CalcL1LeavesSum(LeafValues, Dim);
+        }
+
         const TVector<double>& GetWeights() const {
             return LeafWeights;
         }

--- a/catboost/cuda/targets/weak_objective.h
+++ b/catboost/cuda/targets/weak_objective.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <util/generic/maybe.h>
 #include <util/generic/noncopyable.h>
 #include <catboost/cuda/cuda_lib/cuda_buffer.h>
 #include <catboost/cuda/cuda_util/gpu_random.h>
@@ -24,7 +25,11 @@ namespace NCatboostCuda {
         virtual ~IWeakObjective() {
         }
 
+        /* mvsLambda is the regularization for MVS bootstrap used if mvs_reg is not set explicitly
+         * (usually L1 leaves sum of the previous tree), ignored for other bootstrap types
+         */
         virtual void StochasticDer(const NCatboostOptions::TBootstrapConfig& bootstrapConfig,
+                                   TMaybe<float> mvsLambda,
                                    bool secondDerAsWeights,
                                    TOptimizationTarget* target) const = 0;
 

--- a/catboost/libs/features_selection/select_features.cpp
+++ b/catboost/libs/features_selection/select_features.cpp
@@ -39,6 +39,17 @@ namespace NCB {
             );
         }
 
+        if ((featuresSelectOptions.Algorithm.Get() == EFeaturesSelectionAlgorithm::RecursiveByShapValues) &&
+            (catBoostOptions.ObliviousTreeOptions->GrowPolicy.Get() != EGrowPolicy::SymmetricTree))
+        {
+            const auto shapCalcType = featuresSelectOptions.ShapCalcType.Get();
+            CB_ENSURE(
+                (shapCalcType == ECalcTypeShapValues::Regular) || (shapCalcType == ECalcTypeShapValues::Approximate),
+                "shap_calc_type '" << shapCalcType << "' is supported only for symmetric trees"
+                " (grow_policy=SymmetricTree), use 'Regular' or 'Approximate' for " << catBoostOptions.ObliviousTreeOptions->GrowPolicy.Get()
+            );
+        }
+
         auto checkCountConsistency = [] (
             auto entriesForSelectSize,
             const TOption<int>& numberOfEntriesToSelect,

--- a/catboost/libs/fstr/shap_prepared_trees.cpp
+++ b/catboost/libs/fstr/shap_prepared_trees.cpp
@@ -540,6 +540,13 @@ TShapPreparedTrees PrepareTrees(
     EExplainableModelOutput modelOutputType,
     bool fstrOnTrainPool
 ) {
+    CB_ENSURE(
+        model.IsOblivious()
+            || (calcType == ECalcTypeShapValues::Regular)
+            || (calcType == ECalcTypeShapValues::Approximate),
+        "'" << calcType << "' SHAP values calculation type is supported only for symmetric trees"
+    );
+
     TShapPreparedTrees preparedTrees;
     InitLeafWeights(model, fstrOnTrainPool, dataset, localExecutor, &preparedTrees.LeafWeightsForAllTrees);
     InitPreparedTreesWithoutIndependent(

--- a/catboost/libs/fstr/shap_values.cpp
+++ b/catboost/libs/fstr/shap_values.cpp
@@ -1101,7 +1101,7 @@ static void CalcShapValuesForDocumentBlockMulti(
     shapValuesForAllDocuments->resize(oldShapValuesSize + end - start);
 
     NPar::ILocalExecutor::TExecRangeParams blockParams(0, documentCount);
-    localExecutor->ExecRange([&] (size_t documentIdxInBlock) {
+    localExecutor->ExecRangeWithThrow([&] (size_t documentIdxInBlock) {
         TVector<TVector<double>>& shapValues = (*shapValuesForAllDocuments)[oldShapValuesSize + documentIdxInBlock];
 
         CalcShapValuesForDocumentMulti(
@@ -1117,7 +1117,7 @@ static void CalcShapValuesForDocumentBlockMulti(
             /*documentIdx*/ documentIdxInBlock + start
         );
 
-    }, blockParams, NPar::TLocalExecutor::WAIT_COMPLETE);
+    }, blockParams.FirstId, blockParams.LastId, NPar::TLocalExecutor::WAIT_COMPLETE);
 }
 
 static void CalcShapValuesByLeafForTreeBlock(
@@ -1135,7 +1135,7 @@ static void CalcShapValuesByLeafForTreeBlock(
     const bool isOblivious = forest.GetModelTreeData()->GetNonSymmetricStepNodes().empty() && forest.GetModelTreeData()->GetNonSymmetricNodeIdToLeafId().empty();
 
     NPar::ILocalExecutor::TExecRangeParams blockParams(start, end);
-    localExecutor->ExecRange([&] (size_t treeIdx) {
+    localExecutor->ExecRangeWithThrow([&] (size_t treeIdx) {
         if (preparedTrees->CalcShapValuesByLeafForAllTrees && isOblivious) {
             const size_t leafCount = (size_t(1) << forest.GetModelTreeData()->GetTreeSizes()[treeIdx]);
             TVector<TVector<TShapValue>>& shapValuesByLeaf = preparedTrees->ShapValuesByLeafForAllTrees[treeIdx];
@@ -1201,7 +1201,7 @@ static void CalcShapValuesByLeafForTreeBlock(
                 }
             }
         }
-    }, blockParams, NPar::TLocalExecutor::WAIT_COMPLETE);
+    }, blockParams.FirstId, blockParams.LastId, NPar::TLocalExecutor::WAIT_COMPLETE);
 }
 
 void CalcShapValuesByLeaf(
@@ -1276,7 +1276,7 @@ void CalcShapValuesInternalForFeature(
             MakeArrayRef(indices.data(), binarizedFeaturesForBlock->GetObjectsCount() * forest.GetTreeCount())
         );
 
-        localExecutor->ExecRange([&](ui32 documentIdx) {
+        localExecutor->ExecRangeWithThrow([&](ui32 documentIdx) {
             TVector<TVector<double>> &docShapValues = (*shapValues)[documentIdx];
             docShapValues.assign(featuresCount, TVector<double>(forest.GetDimensionsCount() + 1, 0.0));
             auto docIndices = MakeArrayRef(indices.data() + forest.GetTreeCount() * (documentIdx - startIdx), forest.GetTreeCount());
@@ -1380,7 +1380,7 @@ void CalcShapValuesInternalForFeature(
                     }
                 }
             }
-        }, blockParams, NPar::TLocalExecutor::WAIT_COMPLETE);
+        }, blockParams.FirstId, blockParams.LastId, NPar::TLocalExecutor::WAIT_COMPLETE);
     }
 }
 
@@ -1557,7 +1557,7 @@ TVector<TVector<TVector<double>>> CalcShapValueWithQuantizedData(
         NPar::ILocalExecutor::TExecRangeParams blockParams(startIdx, startIdx + Min(documentBlockSize, documentCount - startIdx));
         auto quantizedFeaturesBlock = quantizedFeatures[blockIdx];
         auto& indicesForBlock = indices[blockIdx];
-        localExecutor->ExecRange([&](ui32 documentIdx) {
+        localExecutor->ExecRangeWithThrow([&](ui32 documentIdx) {
             const size_t documentIdxInBlock = documentIdx - startIdx;
             auto docIndices = MakeArrayRef(indicesForBlock.data() + forest.GetTreeCount() * documentIdxInBlock, forest.GetTreeCount());
             CalcShapValuesForDocumentMulti(
@@ -1571,7 +1571,7 @@ TVector<TVector<TVector<double>>> CalcShapValueWithQuantizedData(
                 &shapValues[documentIdx],
                 calcType
             );
-        }, blockParams, NPar::TLocalExecutor::WAIT_COMPLETE);
+        }, blockParams.FirstId, blockParams.LastId, NPar::TLocalExecutor::WAIT_COMPLETE);
     }
 
     const auto& swapedShapValues = SwapFeatureAndDocumentAxes(shapValues);

--- a/catboost/private/libs/algo/greedy_tensor_search.cpp
+++ b/catboost/private/libs/algo/greedy_tensor_search.cpp
@@ -949,6 +949,10 @@ static void SelectBestCandidate(
     for (const auto& candidatesContext : candidatesContexts) {
         for (const auto& subList : candidatesContext.CandidateList) {
             for (const auto& candidate : subList.Candidates) {
+                if (!candidate.HasBestSplit()) {
+                    // all scores of the candidate are NaN or -inf, there is no split to select
+                    continue;
+                }
                 double score = candidate.BestScore.GetInstance(ctx.LearnProgress->Rand);
                 score *= GetCatFeatureWeight(candidate, ctx, fold, maxFeatureValueCount);
 

--- a/catboost/private/libs/algo/tensor_search_helpers.cpp
+++ b/catboost/private/libs/algo/tensor_search_helpers.cpp
@@ -42,6 +42,8 @@ TSplit TCandidateInfo::GetSplit(
     const TQuantizedObjectsDataProvider& objectsData,
     ui32 oneHotMaxSize
 ) const {
+    CB_ENSURE_INTERNAL(binId >= 0, "GetSplit: invalid bin id " << binId);
+
     auto getCandidateType = [&] (EFeatureType featureType) {
         if (SplitEnsemble.IsEstimated) {
             return ESplitType::EstimatedFeature;

--- a/catboost/private/libs/algo/tensor_search_helpers.h
+++ b/catboost/private/libs/algo/tensor_search_helpers.h
@@ -43,6 +43,14 @@ struct TCandidateInfo {
 public:
     SAVELOAD(SplitEnsemble, BestScore, BestBinId);
 
+    /* false if no split of this candidate has been selected as the best one, e.g. if all scores are NaN
+     * (possible with degenerate derivatives, e.g. because of too small l2 regularization).
+     * GetBestSplit must not be called for such candidates.
+     */
+    bool HasBestSplit() const {
+        return BestBinId >= 0;
+    }
+
     TSplit GetBestSplit(
         const NCB::TTrainingDataProviders& data,
         const TFold& fold,

--- a/catboost/pytest/cuda_tests/test_gpu.py
+++ b/catboost/pytest/cuda_tests/test_gpu.py
@@ -3484,3 +3484,61 @@ def test_mvs_bootstrap(boosting_type, loss_function):
         assert (filecmp.cmp(ref_eval_path, eval_path) is False)
 
     return [local_canonical_file(ref_eval_path)]
+
+
+# MVS bootstrap with non-symmetric trees used to crash (memory corruption) on GPU, see #1935
+@pytest.mark.parametrize('grow_policy', NONSYMMETRIC)
+@pytest.mark.parametrize('loss_function', ['Logloss', 'RMSE'])
+@pytest.mark.parametrize('score_function', ['Cosine', 'NewtonL2'])
+def test_mvs_bootstrap_nonsymmetric(grow_policy, loss_function, score_function):
+    pool = 'airlines_5K'
+    learn_file = data_file(pool, 'train')
+    test_file = data_file(pool, 'test')
+    cd_file = data_file(pool, 'cd')
+
+    def run_catboost(eval_path, mvs_sample_rate, mvs_reg=None):
+        cmd = [
+            CATBOOST_PATH,
+            'fit',
+            '--use-best-model', 'false',
+            '--allow-writing-files', 'false',
+            '--loss-function', loss_function,
+            '--max-ctr-complexity', '5',
+            '-f', learn_file,
+            '-t', test_file,
+            '--column-description', cd_file,
+            '--has-header',
+            '--task-type', 'GPU',
+            '--devices', '0',
+            '--boosting-type', 'Plain',
+            '--grow-policy', grow_policy,
+            '--score-function', score_function,
+            '--bootstrap-type', 'MVS',
+            '--subsample', mvs_sample_rate,
+            '-i', '50',
+            '-w', '0.03',
+            '-T', '6',
+            '-r', '0',
+            '--leaf-estimation-iterations', '10',
+            '--eval-file', eval_path,
+        ]
+        if mvs_reg is not None:
+            cmd += ['--mvs-reg', mvs_reg]
+        yatest.common.execute(cmd)
+
+    def read_eval(eval_path):
+        return np.loadtxt(eval_path, delimiter='\t', skiprows=1, usecols=[1])
+
+    ref_eval_path = yatest.common.test_output_path('test.eval')
+    run_catboost(ref_eval_path, '0.5')
+    ref_eval = read_eval(ref_eval_path)
+    assert np.all(np.isfinite(ref_eval))
+
+    for sample_rate in ('0.1', '0.9'):
+        eval_path = yatest.common.test_output_path('test_{}.eval'.format(sample_rate))
+        run_catboost(eval_path, sample_rate)
+        assert not np.array_equal(ref_eval, read_eval(eval_path))
+
+    eval_path = yatest.common.test_output_path('test_mvs_reg.eval')
+    run_catboost(eval_path, '0.5', mvs_reg='0.1')
+    assert np.all(np.isfinite(read_eval(eval_path)))

--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -5751,8 +5751,8 @@ cdef class _CatBoost:
         cdef EExplainableModelOutput model_output = string_to_model_output(model_output_name)
         cdef TMaybe[pair[int, int]] pair_of_features
 
-        if shap_calc_type == 'Exact':
-            assert dereference(self.__model).IsOblivious(), "'Exact' calculation type is supported only for symmetric trees."
+        if shap_calc_type == 'Exact' and not dereference(self.__model).IsOblivious():
+            raise CatBoostError("'Exact' calculation type is supported only for symmetric trees.")
         cdef ECalcTypeShapValues calc_type = string_to_calc_type(shap_calc_type)
         if reference_data:
             referenceDataProviderPtr = reference_data.__pool

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -10855,6 +10855,80 @@ def test_select_features(task_type, train_final_model):
         assert model.evals_result_ == {}
 
 
+# used to crash with std::terminate (uncaught exception in a worker thread), see #1935
+@pytest.mark.parametrize('grow_policy', ['Depthwise', 'Lossguide'])
+def test_select_features_by_shap_values_unsupported_calc_type_nonsymmetric(task_type, grow_policy):
+    learn = Pool(TRAIN_FILE, column_description=CD_FILE)
+    test = Pool(TEST_FILE, column_description=CD_FILE)
+    model = CatBoostClassifier(
+        iterations=10,
+        learning_rate=0.03,
+        grow_policy=grow_policy,
+        task_type=task_type,
+        gpu_ram_part=TEST_GPU_RAM_PART,
+        devices='0'
+    )
+    with pytest.raises(CatBoostError, match='supported only for symmetric trees'):
+        model.select_features(
+            learn,
+            eval_set=test,
+            steps=1,
+            algorithm='RecursiveByShapValues',
+            shap_calc_type='Exact',
+            train_final_model=False,
+            features_for_select='0-16',
+            num_features_to_select=10
+        )
+
+
+@pytest.mark.parametrize('grow_policy', ['Depthwise', 'Lossguide'])
+def test_select_features_by_shap_values_nonsymmetric(task_type, grow_policy):
+    learn = Pool(TRAIN_FILE, column_description=CD_FILE)
+    test = Pool(TEST_FILE, column_description=CD_FILE)
+    model = CatBoostClassifier(
+        iterations=10,
+        learning_rate=0.03,
+        grow_policy=grow_policy,
+        task_type=task_type,
+        gpu_ram_part=TEST_GPU_RAM_PART,
+        devices='0'
+    )
+    summary = model.select_features(
+        learn,
+        eval_set=test,
+        steps=2,
+        algorithm='RecursiveByShapValues',
+        shap_calc_type='Regular',
+        train_final_model=True,
+        features_for_select='0-16',
+        num_features_to_select=10
+    )
+    assert len(summary['selected_features']) == 10
+    assert model.is_fitted()
+
+
+# 'Independent' calculation type is selected by passing reference_data
+@pytest.mark.parametrize('calc_type', ['Exact', 'Independent'])
+def test_shap_values_unsupported_calc_type_nonsymmetric(task_type, calc_type):
+    learn = Pool(TRAIN_FILE, column_description=CD_FILE)
+    model = CatBoostClassifier(
+        iterations=10,
+        learning_rate=0.03,
+        grow_policy='Depthwise',
+        task_type=task_type,
+        gpu_ram_part=TEST_GPU_RAM_PART,
+        devices='0'
+    )
+    model.fit(learn)
+    with pytest.raises(CatBoostError, match='supported only for symmetric trees'):
+        model.get_feature_importance(
+            learn,
+            type='ShapValues',
+            shap_calc_type='Exact' if calc_type == 'Exact' else 'Regular',
+            reference_data=learn if calc_type == 'Independent' else None
+        )
+
+
 def test_select_features_with_custom_eval_metric():
     class CustomMetric(object):
         def get_final_error(self, error, weight):


### PR DESCRIPTION
Fixes crashes from https://github.com/catboost/catboost/issues/1935 (segfaults and "This should be unreachable / GetSplit() failed" during hyperparameter search, feature selection and training with non-default parameters).

## 1. GPU: segfault / memory corruption with `bootstrap_type=MVS` and non-symmetric trees

Training on GPU with `bootstrap_type=MVS` and `grow_policy=Depthwise`/`Lossguide` (also `Region`) always crashed: segfault or corrupted GPU memory which later surfaced as a spurious `CUDA error 2: out of memory`. It is easy to hit from `grid_search`/`randomized_search`/`select_features` when the search space contains MVS and non-symmetric grow policies.

Root cause: `TGreedySubsetsSearcher` (used for non-symmetric trees) took the bootstrap path that does not support MVS; it was guarded only by `Y_ASSERT` (`greedy_subsets_searcher.h`, `weak_objective_impl.h`, `TBootstrap::BootstrapAndFilter`), which is compiled out in release builds.

Fix: MVS is implemented for the greedy subsets searcher the same way as for oblivious trees:
- derivatives are computed for all samples, MVS weights are computed from them (`MvsBootstrapRadixSort`), applied to the stats, samples with zero weights are filtered out (`TWeakObjective::MvsStochasticDer`);
- `mvs_reg` defaults to the L1 leaves sum of the previous tree (as for oblivious trees), passed via `TTreeStructureSearcherOptions::MvsLambda`; `GetL1LeavesSum()` is added to `TNonSymmetricTree` and `TRegionModel`, the computation is shared in `CalcL1LeavesSum`.

Verified on RTX 5090: the reproducer crashes without the fix and passes with it; `cuda_tests/test_gpu.py -k "grow_polic or nonsymmetric or bootstrap or mvs"` (235 tests incl. canonical comparisons) pass.

## 2. Abort in SHAP values calculation with unsupported calculation type for non-symmetric trees

`select_features(algorithm='RecursiveByShapValues', shap_calc_type='Exact')` and `get_feature_importance(type='ShapValues')` with `Exact` or `Independent` (`reference_data`) calculation types on a Depthwise/Lossguide model terminated the process with SIGABRT on both CPU and GPU: the corresponding `CB_ENSURE` in `shap_values.cpp` was thrown inside a worker thread of `ILocalExecutor::ExecRange`, which does not propagate exceptions, so `std::terminate` was called.

Fix:
- the calculation type is validated in `PrepareTrees` before any parallel computation;
- `select_features` validates `shap_calc_type` against `grow_policy` in `CheckOptions` with an actionable message;
- SHAP calculation loops use `ExecRangeWithThrow`, so any exception is propagated to the caller;
- Python: `CatBoostError` is raised instead of `AssertionError` for `Exact` with non-symmetric trees.

## 3. CPU: hardening of best split selection

`SelectBestCandidate` called `GetBestSplit()` for every candidate, including candidates without a selected split (`BestBinId == -1` when all scores are NaN/-inf, e.g. with degenerate derivatives and very small `l2_leaf_reg`). For feature bundles and groups this produces exactly the reported "This should be unreachable / GetSplit() failed", for other candidates an out-of-range bin id. Such candidates are skipped now (`TCandidateInfo::HasBestSplit`) and `GetSplit` checks the bin id. I could not reproduce this path on current master with randomized parameter fuzzing (~1500 runs, including the exact configuration from the issue), so this is a defensive fix for the reported symptom.

## Tests

- `cuda_tests/test_gpu.py::test_mvs_bootstrap_nonsymmetric` (all non-symmetric grow policies, `Cosine`/`NewtonL2` score functions, explicit `mvs_reg`).
- `python-package/ut/medium/test.py`: `test_select_features_by_shap_values_unsupported_calc_type_nonsymmetric`, `test_select_features_by_shap_values_nonsymmetric`, `test_shap_values_unsupported_calc_type_nonsymmetric`.

Note: the existing `cuda_tests/test_gpu.py::test_mvs_bootstrap` does not pass `--task-type GPU`, so it actually runs on CPU; not changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jnza5UgN86uJuMh7xfUETJ
